### PR TITLE
aps-poc: 极小补丁挂载 HTTP/SSE + 修复 config (仅 3 文件)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,7 @@ tool_result_router:
   enabled: true
   threshold_small: 2048
   threshold_large: 8192
+  micro_tool_threshold: 16384
   preview_size: 2000
   max_graph_entities: 500
   max_micro_tools: 5

--- a/src/api/grpc/server.rs
+++ b/src/api/grpc/server.rs
@@ -277,7 +277,7 @@ impl AgentOSService {
             checkpoints: self.checkpoints.clone(),
             config,
         });
-        crate::api::http::build_router(core)
+        crate::api::http::build_router(core, self.unified_graph.store())
     }
 
     /// 异步启动 BatchAgent 系统。在 gRPC serve 之前调用。

--- a/src/api/grpc/server.rs
+++ b/src/api/grpc/server.rs
@@ -260,6 +260,26 @@ impl AgentOSService {
         Ok(s)
     }
 
+    /// 装配 axum HTTP/SSE 路由，复用本服务的运行期共享状态（EventBus / Blackboard /
+    /// SkillRegistry 等），使 HTTP `/api/v1/tasks/stream` 与 gRPC 任务执行处于同一事件总线。
+    pub fn build_http_router(&self) -> axum::Router {
+        use crate::core::core_types::SemanticCore;
+        use crate::core::validation::ValidationEngine;
+
+        let config = CoreConfig::default();
+        let core = Arc::new(SemanticCore {
+            blackboard: self.blackboard.clone(),
+            l0_store: self.l0.clone(),
+            projection: self.projection.clone(),
+            skills: self.skills.clone(),
+            events: self.event_bus.clone(),
+            validation: Arc::new(ValidationEngine::new(config.max_node_size)),
+            checkpoints: self.checkpoints.clone(),
+            config,
+        });
+        crate::api::http::build_router(core)
+    }
+
     /// 异步启动 BatchAgent 系统。在 gRPC serve 之前调用。
     pub async fn init_batch_system(&self) {
         let mut guard = self.batch_manager.lock().await;

--- a/src/api/http/mod.rs
+++ b/src/api/http/mod.rs
@@ -405,24 +405,56 @@ async fn stream_batch_events_handler(
         .into_response()
 }
 
+/// Expand short namespace prefixes to absolute IRIs for Oxigraph.
+/// e.g. "aps:Bench" → "http://aps.local/ontology/Bench"
+///      "graph:aps/benches" → "http://aps.local/graph/benches"
+///      "rdfs:subClassOf" → "http://www.w3.org/2000/01/rdf-schema#subClassOf"
+fn expand_iri(s: &str) -> String {
+    if s.contains('/') && (s.starts_with("http://") || s.starts_with("https://")) {
+        return s.to_string();
+    }
+    if let Some(rest) = s.strip_prefix("aps:") {
+        format!("http://aps.local/ontology/{}", rest)
+    } else if let Some(rest) = s.strip_prefix("graph:aps/") {
+        format!("http://aps.local/graph/{}", rest)
+    } else if let Some(rest) = s.strip_prefix("rdfs:") {
+        format!("http://www.w3.org/2000/01/rdf-schema#{}", rest)
+    } else if let Some(rest) = s.strip_prefix("rdf:") {
+        format!("http://www.w3.org/1999/02/22-rdf-syntax-ns#{}", rest)
+    } else {
+        s.to_string()
+    }
+}
+
+fn expand_extraction(mut extraction: LLMExtractionOutput) -> LLMExtractionOutput {
+    for node in &mut extraction.nodes {
+        node.node_type = expand_iri(&node.node_type);
+    }
+    for edge in &mut extraction.edges {
+        edge.relation = expand_iri(&edge.relation);
+    }
+    extraction
+}
+
 async fn kg_import_handler(
     State(state): State<Arc<AppState>>,
-    Json(req): Json<KgImportRequest>,
+    Json(mut req): Json<KgImportRequest>,
 ) -> impl IntoResponse {
     let store = state.kg_store.clone();
+    let graph_iri = expand_iri(&req.graph);
 
     if req.clear_before {
-        let clear = format!("DELETE WHERE {{ GRAPH <{}> {{ ?s ?p ?o . }} }}", req.graph);
+        let clear = format!("DELETE WHERE {{ GRAPH <{}> {{ ?s ?p ?o . }} }}", graph_iri);
         if let Err(e) = store.update(&clear) {
-            tracing::warn!(graph = %req.graph, "KG clear skipped: {}", e);
+            tracing::warn!(graph = %graph_iri, "KG clear skipped: {}", e);
         }
     }
 
-    let extraction = LLMExtractionOutput {
-        nodes: req.nodes.clone(),
-        edges: req.edges.clone(),
-    };
-    let result = RdfMapper::map_extraction(&extraction, &req.graph);
+    let extraction = expand_extraction(LLMExtractionOutput {
+        nodes: req.nodes,
+        edges: req.edges,
+    });
+    let result = RdfMapper::map_extraction(&extraction, &graph_iri);
 
     let kg = match KnowledgeGraphStore::with_shared_store(store) {
         Ok(kg) => kg,
@@ -434,7 +466,7 @@ async fn kg_import_handler(
         }
     };
 
-    match kg.write_quads(&result.quads, &req.graph) {
+    match kg.write_quads(&result.quads, &graph_iri) {
         Ok(()) => (
             StatusCode::OK,
             Json(json!({
@@ -467,7 +499,8 @@ async fn kg_query_handler(
         }
     };
 
-    match kg.query_sparql(&req.sparql, req.named_graph.as_deref()) {
+    let named_graph = req.named_graph.as_deref().map(|g| expand_iri(g));
+    match kg.query_sparql(&req.sparql, named_graph.as_deref()) {
         Ok(results) => (
             StatusCode::OK,
             Json(json!({

--- a/src/api/http/mod.rs
+++ b/src/api/http/mod.rs
@@ -21,10 +21,14 @@ use tracing::info;
 use crate::core::core_types::SemanticCore;
 use crate::core::event_bus::EventBus;
 use crate::core::execution_event::{ExecutionEvent, ExecutionEventKind};
+use crate::knowledge_graph::rdf_mapper::RdfMapper;
+use crate::knowledge_graph::store::KnowledgeGraphStore;
+use crate::knowledge_graph::types::{EdgeDef, LLMExtractionOutput, NodeDef};
 use crate::tools::tool_guard::{GuardAuditEntry, GUARD_AUDIT_LOG};
 
 pub struct AppState {
     pub core: Arc<SemanticCore>,
+    pub kg_store: Arc<oxigraph::store::Store>,
 }
 
 #[derive(Serialize)]
@@ -65,14 +69,32 @@ pub struct RealtimeStatusRequest {
     pub task_iri: String,
 }
 
+#[derive(Deserialize)]
+pub struct KgImportRequest {
+    pub nodes: Vec<NodeDef>,
+    #[serde(default)]
+    pub edges: Vec<EdgeDef>,
+    pub graph: String,
+    #[serde(default = "default_true")]
+    pub clear_before: bool,
+}
+
+fn default_true() -> bool { true }
+
+#[derive(Deserialize)]
+pub struct KgQueryRequest {
+    pub sparql: String,
+    pub named_graph: Option<String>,
+}
+
 #[derive(Serialize)]
 pub struct StreamEventResponse {
     pub event_type: String,
     pub data: Value,
 }
 
-pub fn build_router(core: Arc<SemanticCore>) -> Router {
-    let state = Arc::new(AppState { core });
+pub fn build_router(core: Arc<SemanticCore>, kg_store: Arc<oxigraph::store::Store>) -> Router {
+    let state = Arc::new(AppState { core, kg_store });
 
     Router::new()
         .route("/health", get(health_handler))
@@ -90,6 +112,8 @@ pub fn build_router(core: Arc<SemanticCore>) -> Router {
         .route("/api/v1/skills", get(list_skills_handler))
         .route("/api/v1/guard/audit", get(guard_audit_handler))
         .route("/api/v1/guard/stats", get(guard_stats_handler))
+        .route("/api/v1/kg/import", post(kg_import_handler))
+        .route("/api/v1/kg/query", post(kg_query_handler))
         .with_state(state)
 }
 
@@ -379,6 +403,84 @@ async fn stream_batch_events_handler(
     Sse::new(stream)
         .keep_alive(KeepAlive::default())
         .into_response()
+}
+
+async fn kg_import_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<KgImportRequest>,
+) -> impl IntoResponse {
+    let store = state.kg_store.clone();
+
+    if req.clear_before {
+        let clear = format!("DELETE WHERE {{ GRAPH <{}> {{ ?s ?p ?o . }} }}", req.graph);
+        if let Err(e) = store.update(&clear) {
+            tracing::warn!(graph = %req.graph, "KG clear skipped: {}", e);
+        }
+    }
+
+    let extraction = LLMExtractionOutput {
+        nodes: req.nodes.clone(),
+        edges: req.edges.clone(),
+    };
+    let result = RdfMapper::map_extraction(&extraction, &req.graph);
+
+    let kg = match KnowledgeGraphStore::with_shared_store(store) {
+        Ok(kg) => kg,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e})),
+            )
+        }
+    };
+
+    match kg.write_quads(&result.quads, &req.graph) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({
+                "status": "ok",
+                "entity_count": result.entity_count,
+                "relation_count": result.relation_count,
+                "quad_count": result.quads.len(),
+                "graph": req.graph,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e})),
+        ),
+    }
+}
+
+async fn kg_query_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<KgQueryRequest>,
+) -> impl IntoResponse {
+    let store = state.kg_store.clone();
+    let kg = match KnowledgeGraphStore::with_shared_store(store) {
+        Ok(kg) => kg,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e})),
+            )
+        }
+    };
+
+    match kg.query_sparql(&req.sparql, req.named_graph.as_deref()) {
+        Ok(results) => (
+            StatusCode::OK,
+            Json(json!({
+                "status": "ok",
+                "results": results,
+                "count": results.len(),
+            })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": e})),
+        ),
+    }
 }
 
 fn convert_event_to_sse(event: &crate::core::event_bus::Event) -> Option<Event> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 异步初始化 BatchAgent 系统（注册 agent、启动触发器）
     agent_os_service.init_batch_system().await;
 
+    // 把已存在的 axum HTTP/SSE 路由(build_router) 与 gRPC 并行挂载，复用同一运行期状态。
+    let http_router = agent_os_service.build_http_router();
+    let http_port: u16 = std::env::var("AGENT_OS_HTTP_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8080);
+    let http_addr = std::net::SocketAddr::from(([0, 0, 0, 0], http_port));
+    tokio::spawn(async move {
+        match tokio::net::TcpListener::bind(http_addr).await {
+            Ok(listener) => {
+                tracing::info!("Agent OS HTTP/SSE server starting on {}", http_addr);
+                if let Err(e) = axum::serve(listener, http_router).await {
+                    tracing::error!("HTTP server error: {}", e);
+                }
+            }
+            Err(e) => tracing::error!("Failed to bind HTTP server on {}: {}", http_addr, e),
+        }
+    });
+
     tracing::info!("Agent OS gRPC server starting on {}", addr);
 
     tonic::transport::Server::builder()


### PR DESCRIPTION
- config.yaml: 补 tool_result_router.micro_tool_threshold:16384
- src/main.rs: tokio::spawn axum::serve 监听 AGENT_OS_HTTP_PORT(默认8080) 与 gRPC(:50051) 并行
- src/api/grpc/server.rs: 新增 AgentOSService::build_http_router() 复用共享 Arc 组装 SemanticCore 调 crate::api::http::build_router