### PR TITLE
fix(l2): remove duplicated secondary-index update block in write_node

### DIFF
--- a/src/memory/l2_blackboard.rs
+++ b/src/memory/l2_blackboard.rs
@@ -227,34 +227,7 @@ impl Blackboard {
             }
         }
 
-            // ── Update secondary indices for batch ──
-            if let Some(task_iri) = &task_iri {
-                if let Some(role_str) = parsed.get("role").and_then(|v| v.as_str()) {
-                    if let Ok(role) = role_str.parse::<AgentRole>() {
-                        let mut idx = self.role_index.write();
-                        let entry = idx.entry((task_iri.clone(), role)).or_default();
-                        if !entry.contains(&node_iri.to_string()) {
-                            entry.push(node_iri.to_string());
-                        }
-                    }
-                }
-                if let Some(cycle_id) = parsed.get("cycle_id").and_then(|v| v.as_str()) {
-                    let mut idx = self.cycle_index.write();
-                    let entry = idx.entry((task_iri.clone(), cycle_id.to_string())).or_default();
-                    if !entry.contains(&node_iri.to_string()) {
-                        entry.push(node_iri.to_string());
-                    }
-                }
-                if let Some(node_type) = jsonld_types.first() {
-                    let mut idx = self.type_index.write();
-                    let entry = idx.entry((task_iri.clone(), node_type.clone())).or_default();
-                    if !entry.contains(&node_iri.to_string()) {
-                        entry.push(node_iri.to_string());
-                    }
-                }
-            }
-
-            if !is_update {
+        if !is_update {
             self.node_count.fetch_add(1, Ordering::Relaxed);
         }
         self.total_bytes.fetch_add(size as u64, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

`Blackboard::write_node` in `src/memory/l2_blackboard.rs` contains **two identical secondary-index update blocks**. The second one (mislabeled `// ── Update secondary indices for batch ──`) is a copy-paste duplicate of the first.

## Details

After the correct block updates the role / cycle / type indices:

1. A second, identically-behaving block re-acquires the `role_index` / `cycle_index` / `type_index` write locks and repeats the exact same inserts.
2. It is **idempotent** thanks to the `if !entry.contains(...)` dedup guard, so it does **not** corrupt data — but it doubles lock contention and index work on **every** `write_node` call.
3. Its stray over-indentation also broke the indentation of the following `if !is_update` guard.

## Fix

Remove the duplicate block and restore correct indentation. Net change: `1 insertion(+), 28 deletions(-)`.

```
 src/memory/l2_blackboard.rs | 29 +----------------------------
 1 file changed, 1 insertion(+), 28 deletions(-)
```

## Verification

- `cargo check --lib` passes on `main` with this change (the only remaining warning is the pre-existing `prev_summary` unused-assignment in `sa/mod.rs`, unrelated to this PR).
- The retained block is the well-formatted one covering the same role/cycle/type indices, so query behavior is unchanged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author