### PR TITLE
fix(ontology): unify cross-module namespace IRIs

### DIFF
--- a/.github/workflows/namespace-consistency.yml
+++ b/.github/workflows/namespace-consistency.yml
@@ -1,0 +1,16 @@
+name: Namespace Consistency
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Check ontology namespaces
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check namespace consistency
+        run: bash scripts/check_namespace.sh

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ cargo build -p code_cli --release
 
 - **Design Detail** → [`docs/DESIGN_DETAIL.md`](docs/DESIGN_DETAIL.md) · [`docs/DESIGN_DETAIL.zh.md`](docs/DESIGN_DETAIL.zh.md) (中文)
 - **Core Design Philosophy** → [`docs/CORE_DESIGN_PHILOSOPHY.md`](docs/CORE_DESIGN_PHILOSOPHY.md) · [`docs/CORE_DESIGN_PHILOSOPHY.zh.md`](docs/CORE_DESIGN_PHILOSOPHY.zh.md) (中文)
+- **Ontology Namespace Migration** → [`docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md`](docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md)
 - **gRPC Proto** → [`proto/pdca_core.proto`](proto/pdca_core.proto)
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -315,6 +315,7 @@ cargo build -p code_cli --release
 
 - **设计细节** → [`docs/DESIGN_DETAIL.zh.md`](docs/DESIGN_DETAIL.zh.md) · [`docs/DESIGN_DETAIL.md`](docs/DESIGN_DETAIL.md) (English)
 - **核心设计理念** → [`docs/CORE_DESIGN_PHILOSOPHY.zh.md`](docs/CORE_DESIGN_PHILOSOPHY.zh.md) · [`docs/CORE_DESIGN_PHILOSOPHY.md`](docs/CORE_DESIGN_PHILOSOPHY.md) (English)
+- **本体命名空间迁移** → [`docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md`](docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md) (English)
 - **gRPC Proto** → [`proto/pdca_core.proto`](proto/pdca_core.proto)
 
 ---

--- a/apps/gliding_code/src/engine.rs
+++ b/apps/gliding_code/src/engine.rs
@@ -1189,7 +1189,7 @@ impl CodeCliEngine {
         // This gives the KG auto-growing task records queryable via SPARQL.
         {
             use std::fmt::Write as FmtWrite;
-            let mut sparql = String::from("PREFIX task: <https://agent-harness.os/task#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n");
+            let mut sparql = String::from("PREFIX task: <https://agent-os.org/ontology/task#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n");
             let escape_sparql = |s: &str| -> String {
                 s.replace('\\', "\\\\")
                     .replace('\'', "\\'")
@@ -1533,7 +1533,7 @@ impl CodeCliEngine {
     fn write_task_metadata(&self, task_iri: &str, user_input: &str, result: &TaskResult) {
         use std::fmt::Write as FmtWrite;
         let mut sparql = String::from(
-            "PREFIX task: <https://agent-harness.os/task#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+            "PREFIX task: <https://agent-os.org/ontology/task#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
         );
         let escape_sparql = |s: &str| -> String {
             s.replace('\\', "\\\\")

--- a/docs/03-memory-system.md
+++ b/docs/03-memory-system.md
@@ -333,11 +333,11 @@ pub fn get_shared_state(&self, task_iri: &str) -> Result<Option<Value>, CoreErro
 -- 查询所有 Working 的 DA
 SELECT ?agent ?task ?operation WHERE {
   GRAPH <blackboard:shared> {
-    ?agent a <http://agent-os.org/type/AgentSnapshot> ;
-           <http://agent-os.org/prop/agent_role> "Do" ;
-           <http://agent-os.org/prop/status> "Working" ;
-           <http://agent-os.org/prop/current_operation> ?operation ;
-           <http://agent-os.org/prop/task_iri> ?task .
+    ?agent a <https://agent-os.org/ontology/core/AgentSnapshot> ;
+           <https://agent-os.org/ontology/core/agent_role> "Do" ;
+           <https://agent-os.org/ontology/core/status> "Working" ;
+           <https://agent-os.org/ontology/core/current_operation> ?operation ;
+           <https://agent-os.org/ontology/core/task_iri> ?task .
   }
 }
 ```

--- a/docs/07-knowledge-graph.md
+++ b/docs/07-knowledge-graph.md
@@ -93,8 +93,8 @@ graph LR
 
 **属性 key IRI 转换规则**：
 - 含 `/`、`#`、`:` 的 key → 直接使用（已是完整 IRI）
-- 其他 key → 自动加前缀 `https://agentos.ontology/meta/`
-- 例如：`contentHash` → `https://agentos.ontology/meta/contentHash`
+- 其他 key → 自动加前缀 `https://agent-os.org/ontology/meta/`
+- 例如：`contentHash` → `https://agent-os.org/ontology/meta/contentHash`
 
 ### CodeAstExtractor — 代码 AST 提取
 

--- a/docs/12_workspace-filesystem-monitor.md
+++ b/docs/12_workspace-filesystem-monitor.md
@@ -258,7 +258,7 @@ sequenceDiagram
 ```jsonld
 {
   "@context": {
-    "ws": "https://agent-harness.os/workspace#",
+    "ws": "https://agent-os.org/ontology/workspace#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   },
   "@id": "iri://workspace/file/src/main.rs",
@@ -299,7 +299,7 @@ stateDiagram-v2
 
 ```sparql
 -- 列出目录下所有文件及状态
-PREFIX ws: <https://agent-harness.os/workspace#>
+PREFIX ws: <https://agent-os.org/ontology/workspace#>
 SELECT ?path ?size ?state ?lastRead ?lang
 WHERE {
   GRAPH <iri://workspace> {
@@ -314,7 +314,7 @@ WHERE {
 } ORDER BY ?path
 
 -- 查询文件的依赖关系
-PREFIX ws: <https://agent-harness.os/workspace#>
+PREFIX ws: <https://agent-os.org/ontology/workspace#>
 SELECT ?importedBy ?importedByState
 WHERE {
   GRAPH <iri://workspace> {
@@ -324,7 +324,7 @@ WHERE {
 }
 
 -- 统计文件状态分布
-PREFIX ws: <https://agent-harness.os/workspace#>
+PREFIX ws: <https://agent-os.org/ontology/workspace#>
 SELECT ?state (COUNT(?file) as ?count) (SUM(?size) as ?totalBytes)
 WHERE {
   GRAPH <iri://workspace> {

--- a/docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md
+++ b/docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md
@@ -1,0 +1,98 @@
+# Ontology Namespace Migration
+
+## Summary
+
+Gliding Horse uses JSON-LD and RDF across the memory, skill, task, and code
+knowledge subsystems. Those subsystems must use the same IRI for the same
+semantic concept. RDF treats different hosts, schemes, and paths as different
+resources, even when their local names are identical.
+
+The canonical ontology base is now:
+
+```text
+https://agent-os.org/ontology/
+```
+
+Domain namespaces remain intentionally separated below that base:
+
+```text
+https://agent-os.org/ontology/core/
+https://agent-os.org/ontology/agent#
+https://agent-os.org/ontology/task#
+https://agent-os.org/ontology/skill#
+https://agent-os.org/ontology/memory#
+https://agent-os.org/ontology/security#
+https://agent-os.org/ontology/monitoring#
+https://agent-os.org/ontology/template#
+https://agent-os.org/ontology/experience#
+https://agent-os.org/ontology/advisory#
+https://agent-os.org/ontology/node#
+https://agent-os.org/ontology/eng/
+https://agent-os.org/ontology/code/
+https://agent-os.org/ontology/biz/
+```
+
+The domain split is intentional. The previous host split was not: it caused
+the same concepts to be emitted under unrelated IRIs by different modules.
+
+## What changed
+
+The following layers now use the canonical base:
+
+- JSON-LD constants and the embedded `context.json`
+- JSON-LD framing templates
+- L2 triple materialization and L3 SPARQL projections
+- ontology vocabulary and code-AST extraction
+- skill registry and syscall access-control predicates
+- memory, batch, sharing, bridge, and result-router metadata
+- workflow and skill fixtures
+- source examples and regression tests
+
+Generic core terms use the `core` namespace. For example:
+
+```text
+core:Task       → https://agent-os.org/ontology/core/Task
+core:summary    → https://agent-os.org/ontology/core/summary
+task:what      → https://agent-os.org/ontology/task#what
+skill:AtomicSkill → https://agent-os.org/ontology/skill#AtomicSkill
+```
+
+This keeps domain separation while making all modules resolve through one
+canonical ontology authority.
+
+## Historical namespaces
+
+The following namespaces are no longer valid write targets:
+
+```text
+https://pdca-agent.org/...
+https://agent-harness.os/...
+https://agentos.ontology/...
+http://agent-os.org/...
+```
+
+This change intentionally does not silently rewrite arbitrary persisted RDF.
+Existing installations with data written under a historical namespace should
+be migrated explicitly before relying on queries using the canonical IRIs.
+
+For a rolling deployment, the safe order is:
+
+1. Export or snapshot the existing RDF store.
+2. Rewrite known legacy ontology IRIs to their canonical equivalents.
+3. Deploy the canonical writer and query code.
+4. Verify cross-graph joins for Task, Skill, Agent, and core properties.
+5. Keep the snapshot until the migration has been validated in production.
+
+The application should not introduce a permanent `UNION` over every historical
+namespace as a substitute for migration. Such a fallback hides future drift
+and makes query behavior ambiguous.
+
+## Regression protection
+
+`scripts/check_namespace.sh` fails when a historical host appears in source,
+tests, documentation, skills, or workflow files. It runs in the
+`Namespace Consistency` GitHub Actions workflow for pushes and pull requests
+to `main`.
+
+The JSON-LD context unit tests also verify that every registered ontology
+prefix resolves below `https://agent-os.org/ontology/`.

--- a/docs/CORE_DESIGN_PHILOSOPHY.md
+++ b/docs/CORE_DESIGN_PHILOSOPHY.md
@@ -347,7 +347,7 @@ Let's trace how these components work together in a real scenario:
 
 #### Step 2: Skill Discovery (SPARQL Query)
 ```sparql
-PREFIX skill: <https://agent-harness.os/skill#>
+PREFIX skill: <https://agent-os.org/ontology/skill#>
 SELECT ?skill WHERE {
   GRAPH system:skills {
     ?skill a skill:AtomicSkill ;

--- a/docs/CORE_DESIGN_PHILOSOPHY.zh.md
+++ b/docs/CORE_DESIGN_PHILOSOPHY.zh.md
@@ -345,7 +345,7 @@ graph TB
 
 #### 步骤 2：技能发现（SPARQL 查询）
 ```sparql
-PREFIX skill: <https://agent-harness.os/skill#>
+PREFIX skill: <https://agent-os.org/ontology/skill#>
 SELECT ?skill WHERE {
   GRAPH system:skills {
     ?skill a skill:AtomicSkill ;

--- a/docs/DESIGN_DETAIL.md
+++ b/docs/DESIGN_DETAIL.md
@@ -210,7 +210,7 @@ Different developers write skills with different parameter names. JSON-LD `@cont
 ```json
 {
   "@context": {
-    "skill": "https://agent-harness.os/skill#",
+    "skill": "https://agent-os.org/ontology/skill#",
     "skill:inputMapping": {
       "file_path": { "@id": "skill:sourceDataURI" },
       "source_url": { "@id": "skill:sourceDataURI" },
@@ -340,7 +340,7 @@ L3 Projection Engine uses **Frame documents** to declare desired output shape:
 
 ```json
 {
-  "@context": { "exec": "https://agent-harness.os/exec#" },
+  "@context": { "exec": "https://agent-os.org/ontology/exec#" },
   "@type": "task:AnalysisTask",
   "task:subTasks": {
     "@embed": "@always",           // Expand fully
@@ -676,7 +676,7 @@ AA then makes dimension-aware decisions:
 L0 stores all completed tasks as frozen `task:CompletedTaskSnapshot`. SA's pattern recognition organ queries for similar experiences:
 
 ```sparql
-PREFIX task: <https://agent-harness.os/task#>
+PREFIX task: <https://agent-os.org/ontology/task#>
 
 SELECT ?pastTask ?whySimilarity ?howSimilarity
 WHERE {

--- a/docs/DESIGN_DETAIL.zh.md
+++ b/docs/DESIGN_DETAIL.zh.md
@@ -210,7 +210,7 @@ graph LR
 ```json
 {
   "@context": {
-    "skill": "https://agent-harness.os/skill#",
+    "skill": "https://agent-os.org/ontology/skill#",
     "skill:inputMapping": {
       "file_path": { "@id": "skill:sourceDataURI" },
       "source_url": { "@id": "skill:sourceDataURI" },
@@ -340,7 +340,7 @@ L3 投影引擎使用 **Frame 文档**声明所需的输出形状：
 
 ```json
 {
-  "@context": { "exec": "https://agent-harness.os/exec#" },
+  "@context": { "exec": "https://agent-os.org/ontology/exec#" },
   "@type": "task:AnalysisTask",
   "task:subTasks": {
     "@embed": "@always",           // 完全展开
@@ -676,7 +676,7 @@ CA 不只说"通过/不通过"。它**独立审计每个 5W2H 维度**：
 L0 存储所有已完成的任务作为冻结的 `task:CompletedTaskSnapshot`。SA 的模式识别器官查询类似经验：
 
 ```sparql
-PREFIX task: <https://agent-harness.os/task#>
+PREFIX task: <https://agent-os.org/ontology/task#>
 
 SELECT ?pastTask ?whySimilarity ?howSimilarity
 WHERE {

--- a/scripts/check_namespace.sh
+++ b/scripts/check_namespace.sh
@@ -7,15 +7,33 @@ cd "$ROOT"
 SCAN_PATHS=(src apps crates tests docs skills workflow.jsonld)
 LEGACY='pdca-agent\.org|agent-harness\.os|wild-agent-os\.org|agentos\.ontology|http://agent-os\.org'
 
+search_legacy() {
+  if command -v rg >/dev/null 2>&1; then
+    rg -n -i "$LEGACY" "${SCAN_PATHS[@]}" \
+      --glob '!docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md'
+  else
+    grep -R -n -E -i \
+      --exclude='16-ONTOLOGY_NAMESPACE_MIGRATION.md' \
+      "$LEGACY" "${SCAN_PATHS[@]}"
+  fi
+}
+
+search_canonical() {
+  if command -v rg >/dev/null 2>&1; then
+    rg -n 'https://agent-os\.org/ontology/' "${SCAN_PATHS[@]}"
+  else
+    grep -R -n -E 'https://agent-os\.org/ontology/' "${SCAN_PATHS[@]}"
+  fi
+}
+
 # The migration guide intentionally names historical hosts as part of the
 # documented upgrade path, so exclude that one reference-only document.
-if rg -n -i "$LEGACY" "${SCAN_PATHS[@]}" \
-  --glob '!docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md'; then
+if search_legacy; then
   echo "legacy ontology namespace detected"
   exit 1
 fi
 
-if ! rg -n 'https://agent-os\.org/ontology/' "${SCAN_PATHS[@]}" >/dev/null; then
+if ! search_canonical >/dev/null; then
   echo "canonical ontology namespace not found"
   exit 1
 fi

--- a/scripts/check_namespace.sh
+++ b/scripts/check_namespace.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SCAN_PATHS=(src apps crates tests docs skills workflow.jsonld)
+LEGACY='pdca-agent\.org|agent-harness\.os|wild-agent-os\.org|agentos\.ontology|http://agent-os\.org'
+
+# The migration guide intentionally names historical hosts as part of the
+# documented upgrade path, so exclude that one reference-only document.
+if rg -n -i "$LEGACY" "${SCAN_PATHS[@]}" \
+  --glob '!docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md'; then
+  echo "legacy ontology namespace detected"
+  exit 1
+fi
+
+if ! rg -n 'https://agent-os\.org/ontology/' "${SCAN_PATHS[@]}" >/dev/null; then
+  echo "canonical ontology namespace not found"
+  exit 1
+fi
+
+echo "ontology namespace check passed"

--- a/skills/test_skill/skill.jsonld
+++ b/skills/test_skill/skill.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "schema": "https://schema.org/",
-    "skill": "https://agent-harness.os/skill#"
+    "skill": "https://agent-os.org/ontology/skill#"
   },
   "@id": "iri://skills/test_skill",
   "@type": [

--- a/src/batch/persister.rs
+++ b/src/batch/persister.rs
@@ -116,7 +116,7 @@ impl KnowledgePersister {
                 subject: entity_iri.clone(),
                 predicate: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".into(),
                 object: RdfValue::Iri(format!(
-                    "https://agentos.ontology/batch/{}",
+                    "https://agent-os.org/ontology/batch/{}",
                     entity.entity_type
                 )),
                 graph: Some(graph.into()),
@@ -133,7 +133,7 @@ impl KnowledgePersister {
             // confidence
             quads.push(RdfQuad {
                 subject: entity_iri.clone(),
-                predicate: "https://agentos.ontology/core/confidence".into(),
+                predicate: "https://agent-os.org/ontology/core/confidence".into(),
                 object: RdfValue::TypedLiteral(
                     entity.confidence.to_string(),
                     "http://www.w3.org/2001/XMLSchema#float".into(),
@@ -154,7 +154,7 @@ impl KnowledgePersister {
             // Source batch
             quads.push(RdfQuad {
                 subject: entity_iri.clone(),
-                predicate: "https://agentos.ontology/core/source".into(),
+                predicate: "https://agent-os.org/ontology/core/source".into(),
                 object: RdfValue::Iri(format!("batch://source/{}", domain)),
                 graph: Some(graph.into()),
             });
@@ -185,7 +185,7 @@ impl KnowledgePersister {
         for relation in relations {
             let from_iri = entity_iri(domain, &relation.from);
             let to_iri = entity_iri(domain, &relation.to);
-            let rel_iri = format!("https://agentos.ontology/relation/{}", relation.relation);
+            let rel_iri = format!("https://agent-os.org/ontology/relation/{}", relation.relation);
 
             quads.push(RdfQuad {
                 subject: from_iri,

--- a/src/core/agent_runner/tests.rs
+++ b/src/core/agent_runner/tests.rs
@@ -166,7 +166,7 @@ fn test_token_optimization_settings_wired() {
 fn test_parse_jsonld_response_valid() {
     let runner = create_test_runner();
     let response = json!({
-        "@context": "https://pdca-agent.org/context/task",
+        "@context": "https://agent-os.org/context/task",
         "@id": "iri://task/test123",
         "@type": "TaskNode",
         "summary": "Test task",

--- a/src/core/five_w2h.rs
+++ b/src/core/five_w2h.rs
@@ -762,7 +762,7 @@ impl Task5W2H {
 
         let mut result = json!({
             "@context": {
-                "task": "https://pdca-agent.org/ontology/task#"
+                "task": "https://agent-os.org/ontology/task#"
             },
             "@id": id,
             "@type": "task:5W2H",

--- a/src/core/syscall_gate.rs
+++ b/src/core/syscall_gate.rs
@@ -303,7 +303,7 @@ impl SyscallGate {
         if let Some(iris) = self.agent_whitelist.get(agent_id) {
             for iri in iris {
                 let sparql = format!(
-                    "INSERT DATA {{ GRAPH <{graph}> {{ <{iri}> <https://agent-harness.os/skill#accessibleTool> \"true\" . }} }}",
+                    "INSERT DATA {{ GRAPH <{graph}> {{ <{iri}> <https://agent-os.org/ontology/skill#accessibleTool> \"true\" . }} }}",
                     graph = graph, iri = iri
                 );
                 blackboard.sparql_update(&sparql)?;
@@ -321,7 +321,7 @@ impl SyscallGate {
     ) -> Result<Vec<String>, CoreError> {
         let graph = format!("iri://whitelist/{}", agent_id);
         let sparql = format!(
-            "SELECT ?iri WHERE {{ GRAPH <{graph}> {{ ?iri a <https://agent-harness.os/skill#AccessibleTool> }} }}",
+            "SELECT ?iri WHERE {{ GRAPH <{graph}> {{ ?iri a <https://agent-os.org/ontology/skill#AccessibleTool> }} }}",
             graph = graph
         );
         let results = blackboard.query(&sparql)?;

--- a/src/graph_backend.rs
+++ b/src/graph_backend.rs
@@ -246,7 +246,7 @@ impl GraphBackend for SparqlBackend {
                     .map(|s| s.to_string())
                     .filter(|s| {
                         !s.starts_with("http://www.w3.org/")
-                            && !s.starts_with("https://agentos.ontology")
+                            && !s.starts_with("https://agent-os.org/ontology/")
                     })
                     .collect();
                 nodes.sort();
@@ -866,7 +866,7 @@ impl FeatureGraph for SparqlFeatureGraph {
         .iter()
         .filter_map(|r| r.get("?s").and_then(|v| v.as_str()))
         .filter(|s| {
-            !s.starts_with("http://www.w3.org/") && !s.starts_with("https://agentos.ontology")
+            !s.starts_with("http://www.w3.org/") && !s.starts_with("https://agent-os.org/ontology/")
         })
         .map(|s| s.to_string())
         .collect()

--- a/src/jsonld/context.json
+++ b/src/jsonld/context.json
@@ -1,239 +1,240 @@
 {
   "@context": {
-    "@vocab": "https://pdca-agent.org/vocab#",
+    "@vocab": "https://agent-os.org/ontology/core/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
 
-    "agent": "https://pdca-agent.org/ontology/agent#",
-    "task": "https://pdca-agent.org/ontology/task#",
-    "skill": "https://pdca-agent.org/ontology/skill#",
-    "mem": "https://pdca-agent.org/ontology/memory#",
-    "sec": "https://pdca-agent.org/ontology/security#",
-    "mon": "https://pdca-agent.org/ontology/monitoring#",
-    "tmpl": "https://pdca-agent.org/ontology/template#",
-    "exp": "https://pdca-agent.org/ontology/experience#",
-    "adv": "https://pdca-agent.org/ontology/advisory#",
-    "node": "https://pdca-agent.org/ontology/node#",
+    "core": "https://agent-os.org/ontology/core/",
+    "agent": "https://agent-os.org/ontology/agent#",
+    "task": "https://agent-os.org/ontology/task#",
+    "skill": "https://agent-os.org/ontology/skill#",
+    "mem": "https://agent-os.org/ontology/memory#",
+    "sec": "https://agent-os.org/ontology/security#",
+    "mon": "https://agent-os.org/ontology/monitoring#",
+    "tmpl": "https://agent-os.org/ontology/template#",
+    "exp": "https://agent-os.org/ontology/experience#",
+    "adv": "https://agent-os.org/ontology/advisory#",
+    "node": "https://agent-os.org/ontology/node#",
 
-    "Task": "pdca:Task",
-    "Agent": "pdca:Agent",
-    "PlanNode": "pdca:PlanNode",
-    "ExecutionResult": "pdca:ExecutionResult",
-    "CheckResult": "pdca:CheckResult",
-    "Decision": "pdca:Decision",
-    "EmphasisContent": "pdca:EmphasisContent",
+    "Task": "core:Task",
+    "Agent": "core:Agent",
+    "PlanNode": "core:PlanNode",
+    "ExecutionResult": "core:ExecutionResult",
+    "CheckResult": "core:CheckResult",
+    "Decision": "core:Decision",
+    "EmphasisContent": "core:EmphasisContent",
 
     "task_iri": {
-      "@id": "pdca:taskIri",
+      "@id": "core:taskIri",
       "@type": "@id"
     },
     "agent_id": {
-      "@id": "pdca:agentId",
+      "@id": "core:agentId",
       "@type": "xsd:string"
     },
     "role": {
-      "@id": "pdca:role",
+      "@id": "core:role",
       "@type": "@vocab"
     },
     "status": {
-      "@id": "pdca:status",
+      "@id": "core:status",
       "@type": "xsd:string"
     },
     "summary": {
-      "@id": "pdca:summary",
+      "@id": "core:summary",
       "@type": "xsd:string"
     },
     "objective": {
-      "@id": "pdca:objective",
+      "@id": "core:objective",
       "@type": "xsd:string"
     },
     "content": {
-      "@id": "pdca:content",
+      "@id": "core:content",
       "@type": "xsd:string"
     },
     "thought": {
-      "@id": "pdca:thought",
+      "@id": "core:thought",
       "@type": "xsd:string"
     },
     "emphasis": {
-      "@id": "pdca:emphasis",
+      "@id": "core:emphasis",
       "@type": "xsd:string"
     },
     "timestamp": {
-      "@id": "pdca:timestamp",
+      "@id": "core:timestamp",
       "@type": "xsd:dateTime"
     },
     "permanent": {
-      "@id": "pdca:permanent",
+      "@id": "core:permanent",
       "@type": "xsd:boolean"
     },
     "confidence": {
-      "@id": "pdca:confidence",
+      "@id": "core:confidence",
       "@type": "xsd:float"
     },
     "turn_count": {
-      "@id": "pdca:turnCount",
+      "@id": "core:turnCount",
       "@type": "xsd:integer"
     },
     "tool_call_count": {
-      "@id": "pdca:toolCallCount",
+      "@id": "core:toolCallCount",
       "@type": "xsd:integer"
     },
     "dependencies": {
-      "@id": "pdca:dependsOn",
+      "@id": "core:dependsOn",
       "@type": "@id"
     },
     "created_by": {
-      "@id": "pdca:createdBy",
+      "@id": "core:createdBy",
       "@type": "@id"
     },
     "parent_task": {
-      "@id": "pdca:parentTask",
+      "@id": "core:parentTask",
       "@type": "@id"
     },
     "subtasks": {
-      "@id": "pdca:hasSubtask",
+      "@id": "core:hasSubtask",
       "@type": "@id"
     },
     "artifacts": {
-      "@id": "pdca:hasArtifact",
+      "@id": "core:hasArtifact",
       "@type": "@id"
     },
     "errors": {
-      "@id": "pdca:hasError",
+      "@id": "core:hasError",
       "@type": "xsd:string"
     },
     "tags": {
-      "@id": "pdca:hasTag",
+      "@id": "core:hasTag",
       "@type": "xsd:string"
     },
 
     "created_at": {
-      "@id": "pdca:createdAt",
+      "@id": "core:createdAt",
       "@type": "xsd:dateTime"
     },
     "updated_at": {
-      "@id": "pdca:updatedAt",
+      "@id": "core:updatedAt",
       "@type": "xsd:dateTime"
     },
     "priority": {
-      "@id": "pdca:priority",
+      "@id": "core:priority",
       "@type": "xsd:string"
     },
     "assignee": {
-      "@id": "pdca:assignee",
+      "@id": "core:assignee",
       "@type": "@id"
     },
     "what": {
-      "@id": "pdca:what",
+      "@id": "core:what",
       "@type": "xsd:string"
     },
     "why": {
-      "@id": "pdca:why",
+      "@id": "core:why",
       "@type": "xsd:string"
     },
     "who": {
-      "@id": "pdca:who",
+      "@id": "core:who",
       "@type": "xsd:string"
     },
     "when": {
-      "@id": "pdca:when",
+      "@id": "core:when",
       "@type": "xsd:string"
     },
     "where": {
-      "@id": "pdca:where",
+      "@id": "core:where",
       "@type": "xsd:string"
     },
     "how": {
-      "@id": "pdca:how",
+      "@id": "core:how",
       "@type": "xsd:string"
     },
     "how_much": {
-      "@id": "pdca:howMuch",
+      "@id": "core:howMuch",
       "@type": "xsd:string"
     },
     "success_criteria": {
-      "@id": "pdca:successCriteria",
+      "@id": "core:successCriteria",
       "@type": "xsd:string"
     },
     "description": {
-      "@id": "pdca:description",
+      "@id": "core:description",
       "@type": "xsd:string"
     },
     "deadline": {
-      "@id": "pdca:deadline",
+      "@id": "core:deadline",
       "@type": "xsd:dateTime"
     },
     "data_sources": {
-      "@id": "pdca:dataSources",
+      "@id": "core:dataSources",
       "@type": "@id"
     },
     "execution_environment": {
-      "@id": "pdca:executionEnvironment",
+      "@id": "core:executionEnvironment",
       "@type": "xsd:string"
     },
     "plan_iri": {
-      "@id": "pdca:planIRI",
+      "@id": "core:planIRI",
       "@type": "@id"
     },
     "preferred_skills": {
-      "@id": "pdca:preferredSkills",
+      "@id": "core:preferredSkills",
       "@type": "@id"
     },
     "forbidden_tools": {
-      "@id": "pdca:forbiddenTools",
+      "@id": "core:forbiddenTools",
       "@type": "xsd:string"
     },
     "required_steps": {
-      "@id": "pdca:requiredSteps",
+      "@id": "core:requiredSteps",
       "@type": "xsd:string"
     },
     "token_budget": {
-      "@id": "pdca:tokenBudget",
+      "@id": "core:tokenBudget",
       "@type": "xsd:integer"
     },
     "max_pdca_cycles": {
-      "@id": "pdca:maxPDCACycles",
+      "@id": "core:maxPDCACycles",
       "@type": "xsd:integer"
     },
     "actual_cost": {
-      "@id": "pdca:actualCost",
+      "@id": "core:actualCost",
       "@type": "xsd:integer"
     },
     "requestor": {
-      "@id": "pdca:requestor",
+      "@id": "core:requestor",
       "@type": "@id"
     },
     "required_role": {
-      "@id": "pdca:requiredRole",
+      "@id": "core:requiredRole",
       "@type": "xsd:string"
     },
     "access_level": {
-      "@id": "pdca:accessLevel",
+      "@id": "core:accessLevel",
       "@type": "xsd:string"
     },
     "agent_status": {
-      "@id": "pdca:agentStatus",
+      "@id": "core:agentStatus",
       "@type": "xsd:string"
     },
     "agent_role": {
-      "@id": "pdca:agentRole",
+      "@id": "core:agentRole",
       "@type": "xsd:string"
     },
     "skill_name": {
-      "@id": "pdca:skillName",
+      "@id": "core:skillName",
       "@type": "xsd:string"
     },
     "skill_version": {
-      "@id": "pdca:skillVersion",
+      "@id": "core:skillVersion",
       "@type": "xsd:string"
     },
     "memory_key": {
-      "@id": "pdca:memoryKey",
+      "@id": "core:memoryKey",
       "@type": "xsd:string"
     },
     "memory_value": {
-      "@id": "pdca:memoryValue",
+      "@id": "core:memoryValue",
       "@type": "xsd:string"
     }
   }

--- a/src/jsonld/context.rs
+++ b/src/jsonld/context.rs
@@ -34,17 +34,19 @@ pub const NS_TMPL: &str = "tmpl";
 pub const NS_EXP: &str = "exp";
 pub const NS_ADV: &str = "adv";
 pub const NS_NODE: &str = "node";
+pub const NS_CORE: &str = "core";
 
-pub const URI_AGENT: &str = "https://pdca-agent.org/ontology/agent#";
-pub const URI_TASK: &str = "https://pdca-agent.org/ontology/task#";
-pub const URI_SKILL: &str = "https://pdca-agent.org/ontology/skill#";
-pub const URI_MEM: &str = "https://pdca-agent.org/ontology/memory#";
-pub const URI_SEC: &str = "https://pdca-agent.org/ontology/security#";
-pub const URI_MON: &str = "https://pdca-agent.org/ontology/monitoring#";
-pub const URI_TMPL: &str = "https://pdca-agent.org/ontology/template#";
-pub const URI_EXP: &str = "https://pdca-agent.org/ontology/experience#";
-pub const URI_ADV: &str = "https://pdca-agent.org/ontology/advisory#";
-pub const URI_NODE: &str = "https://pdca-agent.org/ontology/node#";
+pub const URI_CORE: &str = "https://agent-os.org/ontology/core/";
+pub const URI_AGENT: &str = "https://agent-os.org/ontology/agent#";
+pub const URI_TASK: &str = "https://agent-os.org/ontology/task#";
+pub const URI_SKILL: &str = "https://agent-os.org/ontology/skill#";
+pub const URI_MEM: &str = "https://agent-os.org/ontology/memory#";
+pub const URI_SEC: &str = "https://agent-os.org/ontology/security#";
+pub const URI_MON: &str = "https://agent-os.org/ontology/monitoring#";
+pub const URI_TMPL: &str = "https://agent-os.org/ontology/template#";
+pub const URI_EXP: &str = "https://agent-os.org/ontology/experience#";
+pub const URI_ADV: &str = "https://agent-os.org/ontology/advisory#";
+pub const URI_NODE: &str = "https://agent-os.org/ontology/node#";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonLdContext {
@@ -110,6 +112,7 @@ impl JsonLdContext {
         // re-injecting them via named constants ensures they aren't broken by accidentally deleted context.json fields.
         // Values are identical (guaranteed by const URI_* constants), duplicate insertion is a no-op.
         for (prefix, uri) in [
+            ("core", URI_CORE),
             ("agent", URI_AGENT),
             ("task", URI_TASK),
             ("skill", URI_SKILL),
@@ -223,6 +226,7 @@ mod tests {
     #[test]
     fn test_context_value_contains_namespaces() {
         let ctx = JsonLdContext::context_value();
+        assert_eq!(ctx.get("core").and_then(Value::as_str), Some(URI_CORE));
         assert!(ctx.get("agent").is_some());
         assert!(ctx.get("task").is_some());
         assert!(ctx.get("skill").is_some());
@@ -230,12 +234,12 @@ mod tests {
 
     #[test]
     fn test_map_field_to_iri() {
-        assert_eq!(map_field_to_iri("summary"), "pdca:summary");
-        assert_eq!(map_field_to_iri("status"), "pdca:status");
-        assert_eq!(map_field_to_iri("confidence"), "pdca:confidence");
-        assert_eq!(map_field_to_iri("created_at"), "pdca:createdAt");
-        assert_eq!(map_field_to_iri("what"), "pdca:what");
-        assert_eq!(map_field_to_iri("plan_iri"), "pdca:planIRI");
+        assert_eq!(map_field_to_iri("summary"), "core:summary");
+        assert_eq!(map_field_to_iri("status"), "core:status");
+        assert_eq!(map_field_to_iri("confidence"), "core:confidence");
+        assert_eq!(map_field_to_iri("created_at"), "core:createdAt");
+        assert_eq!(map_field_to_iri("what"), "core:what");
+        assert_eq!(map_field_to_iri("plan_iri"), "core:planIRI");
         assert_eq!(map_field_to_iri("@id"), "@id");
         assert_eq!(map_field_to_iri("unknown_field"), "node:unknown_field");
     }
@@ -247,6 +251,23 @@ mod tests {
         assert!(ctx.contains_key("skill_version"));
         assert!(ctx.contains_key("summary"));
         assert!(ctx.contains_key("status"));
+    }
+
+    #[test]
+    fn test_context_uses_canonical_namespace() {
+        let ctx = JsonLdContext::context_value();
+        for prefix in [
+            "core", "agent", "task", "skill", "mem", "sec", "mon", "tmpl", "exp", "adv", "node",
+        ] {
+            let uri = ctx
+                .get(prefix)
+                .and_then(Value::as_str)
+                .expect("namespace must be a string");
+            assert!(
+                uri.starts_with("https://agent-os.org/ontology/"),
+                "{prefix} namespace is not canonical: {uri}"
+            );
+        }
     }
 
     #[test]

--- a/src/jsonld/framing.rs
+++ b/src/jsonld/framing.rs
@@ -415,8 +415,8 @@ fn filter_to_summary(node: &Value) -> Value {
 
 pub static PLAN_CONTEXT_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
     FrameTemplate::new(json!({
-        "exec": "https://agent-harness.os/exec#",
-        "task": "https://agent-harness.os/task#"
+        "exec": "https://agent-os.org/ontology/exec#",
+        "task": "https://agent-os.org/ontology/task#"
     }))
     .with_embed_rule("task:subTasks".to_string(), EmbedDirective::Always)
     .with_embed_rule("exec:assignedTo".to_string(), EmbedDirective::Link)
@@ -426,8 +426,8 @@ pub static PLAN_CONTEXT_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
 
 pub static DA_INPUT_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
     FrameTemplate::new(json!({
-        "exec": "https://agent-harness.os/exec#",
-        "task": "https://agent-harness.os/task#"
+        "exec": "https://agent-os.org/ontology/exec#",
+        "task": "https://agent-os.org/ontology/task#"
     }))
     .with_embed_rule("task:inputData".to_string(), EmbedDirective::Always)
     .with_embed_rule("task:resources".to_string(), EmbedDirective::Link)
@@ -437,8 +437,8 @@ pub static DA_INPUT_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
 
 pub static CA_REVIEW_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
     FrameTemplate::new(json!({
-        "exec": "https://agent-harness.os/exec#",
-        "task": "https://agent-harness.os/task#"
+        "exec": "https://agent-os.org/ontology/exec#",
+        "task": "https://agent-os.org/ontology/task#"
     }))
     .with_embed_rule("exec:results".to_string(), EmbedDirective::Always)
     .with_embed_rule("exec:validationRules".to_string(), EmbedDirective::Always)
@@ -448,8 +448,8 @@ pub static CA_REVIEW_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
 
 pub static AA_DECISION_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
     FrameTemplate::new(json!({
-        "exec": "https://agent-harness.os/exec#",
-        "task": "https://agent-harness.os/task#"
+        "exec": "https://agent-os.org/ontology/exec#",
+        "task": "https://agent-os.org/ontology/task#"
     }))
     .with_embed_rule("exec:reviewResults".to_string(), EmbedDirective::Always)
     .with_embed_rule("exec:alternatives".to_string(), EmbedDirective::Link)
@@ -459,7 +459,7 @@ pub static AA_DECISION_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
 
 pub static SUMMARY_ONLY_FRAME: Lazy<FrameTemplate> = Lazy::new(|| {
     FrameTemplate::new(json!({
-        "agent": "https://agent-harness.os/agent#"
+        "agent": "https://agent-os.org/ontology/agent#"
     }))
     .with_embed_rule("agent:summary".to_string(), EmbedDirective::Always)
     .with_embed_rule("agent:pinnedIRIs".to_string(), EmbedDirective::Link)

--- a/src/jsonld/registry.rs
+++ b/src/jsonld/registry.rs
@@ -161,7 +161,7 @@ impl IriRegistry {
         let sparql = format!(
             "SELECT ?iri WHERE {{
                 GRAPH <{}> {{
-                    ?iri <https://pdca-agent.org/vocab#namespace> \"{}\" .
+                    ?iri <https://agent-os.org/ontology/core/namespace> \"{}\" .
                 }}
             }}",
             self.registry_graph,
@@ -203,7 +203,7 @@ impl IriRegistry {
         let sparql = format!(
             "SELECT ?iri WHERE {{
                 GRAPH <{}> {{
-                    ?iri <https://pdca-agent.org/vocab#entityType> \"{}\" .
+                    ?iri <https://agent-os.org/ontology/core/entityType> \"{}\" .
                 }}
             }}",
             self.registry_graph,
@@ -243,7 +243,7 @@ impl IriRegistry {
     pub fn find_duplicates(&self) -> Vec<IriConflict> {
         let sparql = format!(
             "SELECT ?iri (COUNT(DISTINCT ?namedGraph) AS ?graphCount) WHERE {{
-                GRAPH <{}> {{ ?iri <https://pdca-agent.org/vocab#namedGraph> ?namedGraph . }}
+                GRAPH <{}> {{ ?iri <https://agent-os.org/ontology/core/namedGraph> ?namedGraph . }}
             }} GROUP BY ?iri HAVING (?graphCount > 1)",
             self.registry_graph
         );
@@ -281,12 +281,12 @@ impl IriRegistry {
         let sparql = format!(
             "INSERT DATA {{
                 GRAPH <{}> {{
-                    <{}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://pdca-agent.org/vocab#RegisteredEntity> ;
-                        <https://pdca-agent.org/vocab#namespace> \"{}\" ;
-                        <https://pdca-agent.org/vocab#storageLayer> \"{}\" ;
-                        <https://pdca-agent.org/vocab#namedGraph> \"{}\" ;
-                        <https://pdca-agent.org/vocab#entityType> \"{}\" ;
-                        <https://pdca-agent.org/vocab#createdAt> \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+                    <{}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://agent-os.org/ontology/core/RegisteredEntity> ;
+                        <https://agent-os.org/ontology/core/namespace> \"{}\" ;
+                        <https://agent-os.org/ontology/core/storageLayer> \"{}\" ;
+                        <https://agent-os.org/ontology/core/namedGraph> \"{}\" ;
+                        <https://agent-os.org/ontology/core/entityType> \"{}\" ;
+                        <https://agent-os.org/ontology/core/createdAt> \"{}\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
                 }}
             }}",
             self.registry_graph,
@@ -307,11 +307,11 @@ impl IriRegistry {
     fn query_store(&self, iri: &str) -> Result<Vec<EntityLocation>, String> {
         let sparql = format!(
             "SELECT ?namespace ?namedGraph ?storageLayer ?entityType ?createdAt WHERE {{
-                GRAPH <{}> {{ <{}> <https://pdca-agent.org/vocab#namespace> ?namespace ;
-                    <https://pdca-agent.org/vocab#storageLayer> ?storageLayer .
-                OPTIONAL {{ <{}> <https://pdca-agent.org/vocab#namedGraph> ?namedGraph . }}
-                OPTIONAL {{ <{}> <https://pdca-agent.org/vocab#entityType> ?entityType . }}
-                OPTIONAL {{ <{}> <https://pdca-agent.org/vocab#createdAt> ?createdAt . }}
+                GRAPH <{}> {{ <{}> <https://agent-os.org/ontology/core/namespace> ?namespace ;
+                    <https://agent-os.org/ontology/core/storageLayer> ?storageLayer .
+                OPTIONAL {{ <{}> <https://agent-os.org/ontology/core/namedGraph> ?namedGraph . }}
+                OPTIONAL {{ <{}> <https://agent-os.org/ontology/core/entityType> ?entityType . }}
+                OPTIONAL {{ <{}> <https://agent-os.org/ontology/core/createdAt> ?createdAt . }}
                 }}
             }}",
             self.registry_graph, iri, iri, iri, iri

--- a/src/jsonld/types.rs
+++ b/src/jsonld/types.rs
@@ -81,7 +81,7 @@ pub struct JsonLdNode {
 impl JsonLdNode {
     pub fn new(id: String, node_type: impl Into<Value>) -> Self {
         Self {
-            context: Value::String("https://pdca-agent.org/context/task".to_string()),
+            context: Value::String("https://agent-os.org/context/task".to_string()),
             id,
             node_type: node_type.into(),
             properties: HashMap::new(),
@@ -192,7 +192,7 @@ pub struct SummaryNode {
 impl SummaryNode {
     pub fn new(iri: String, node_type: String, summary: String) -> Self {
         Self {
-            context: "https://pdca-agent.org/context/task".to_string(),
+            context: "https://agent-os.org/context/task".to_string(),
             iri,
             node_type,
             summary,
@@ -238,7 +238,7 @@ pub struct FullNode {
 impl FullNode {
     pub fn new(iri: String, node_type: impl Into<Value>) -> Self {
         Self {
-            context: "https://pdca-agent.org/context/task".to_string(),
+            context: "https://agent-os.org/context/task".to_string(),
             iri,
             node_type: node_type.into(),
             properties: HashMap::new(),
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn test_jsonld_node_from_json() {
         let json = json!({
-            "@context": "https://pdca-agent.org/context/task",
+            "@context": "https://agent-os.org/context/task",
             "@id": "iri://task/456",
             "@type": "TaskNode",
             "summary": "Test task"

--- a/src/knowledge_graph/bridge.rs
+++ b/src/knowledge_graph/bridge.rs
@@ -50,9 +50,9 @@ impl KnowledgeBridge {
 
     fn relation_to_iri(relation: &BridgeRelationType) -> &'static str {
         match relation {
-            BridgeRelationType::HasSkill => "https://agentos.ontology/bridge/hasSkill",
-            BridgeRelationType::ApplicableIn => "https://agentos.ontology/bridge/applicableIn",
-            BridgeRelationType::RelatedTo => "https://agentos.ontology/bridge/relatedTo",
+            BridgeRelationType::HasSkill => "https://agent-os.org/ontology/bridge/hasSkill",
+            BridgeRelationType::ApplicableIn => "https://agent-os.org/ontology/bridge/applicableIn",
+            BridgeRelationType::RelatedTo => "https://agent-os.org/ontology/bridge/relatedTo",
         }
     }
 
@@ -233,7 +233,7 @@ mod tests {
             .unwrap();
 
         // Then: the data must be visible through the original kg_store
-        let sparql = "SELECT ?skill WHERE { <iri://entity/entity_shared> <https://agentos.ontology/bridge/hasSkill> ?skill }";
+        let sparql = "SELECT ?skill WHERE { <iri://entity/entity_shared> <https://agent-os.org/ontology/bridge/hasSkill> ?skill }";
         let results = kg_store.query_sparql(sparql, Some("graph:bridge")).unwrap();
         let skills: Vec<&str> = results
             .iter()

--- a/src/knowledge_graph/code_ast.rs
+++ b/src/knowledge_graph/code_ast.rs
@@ -130,7 +130,7 @@ fn compute_sha256(content: &str) -> String {
 fn get_cached_hash(store: &KnowledgeGraphStore, file_path: &str, graph: &str) -> Option<String> {
     let subject_iri = format!("iri://entity/file:{}", file_path);
     let sparql = format!(
-        "SELECT ?hash WHERE {{ GRAPH <{}> {{ <{}> <https://agentos.ontology/meta/contentHash> ?hash . }} }}",
+        "SELECT ?hash WHERE {{ GRAPH <{}> {{ <{}> <https://agent-os.org/ontology/meta/contentHash> ?hash . }} }}",
         graph, subject_iri
     );
     match store.query_sparql(&sparql, None) {
@@ -286,7 +286,7 @@ impl CodeAstExtractor {
         entities.push(AstEntity {
             id: file_entity_id.clone(),
             label: file_path.to_string(),
-            entity_type: "https://agentos.ontology/code/SourceFile".to_string(),
+            entity_type: "https://agent-os.org/ontology/code/SourceFile".to_string(),
             description: Some(format!("{} source file", lang.name())),
             properties: {
                 let mut props = HashMap::new();
@@ -316,7 +316,7 @@ impl CodeAstExtractor {
                 relations.push(AstRelation {
                     source: file_entity_id.clone(),
                     target: entity.id.clone(),
-                    relation: "https://agentos.ontology/code/contains".to_string(),
+                    relation: "https://agent-os.org/ontology/code/contains".to_string(),
                 });
             }
         }
@@ -403,7 +403,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Function".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Function".to_string(),
                             description: Some(format!("fn {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -427,7 +427,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Struct".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Struct".to_string(),
                             description: Some(format!("struct {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -446,7 +446,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Enum".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Enum".to_string(),
                             description: Some(format!("enum {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -465,7 +465,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Trait".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Trait".to_string(),
                             description: Some(format!("trait {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -495,12 +495,12 @@ impl CodeAstExtractor {
                             relations.push(AstRelation {
                                 source: type_id,
                                 target: trait_id,
-                                relation: "https://agentos.ontology/code/implements".to_string(),
+                                relation: "https://agent-os.org/ontology/code/implements".to_string(),
                             });
                             entities.push(AstEntity {
                                 id: impl_id,
                                 label: format!("impl {} for {}", trait_name, type_name),
-                                entity_type: "https://agentos.ontology/code/Impl".to_string(),
+                                entity_type: "https://agent-os.org/ontology/code/Impl".to_string(),
                                 description: Some(format!("impl {} for {}", trait_name, type_name)),
                                 properties: HashMap::new(),
                                 source_location: Some(format!(
@@ -526,7 +526,7 @@ impl CodeAstExtractor {
                                 entities.push(AstEntity {
                                     id: id.clone(),
                                     label: name.clone(),
-                                    entity_type: "https://agentos.ontology/code/Method".to_string(),
+                                    entity_type: "https://agent-os.org/ontology/code/Method".to_string(),
                                     description: Some(format!("method {}", name)),
                                     properties: HashMap::new(),
                                     source_location: Some(format!(
@@ -555,7 +555,7 @@ impl CodeAstExtractor {
                     entities.push(AstEntity {
                         id: id.clone(),
                         label: use_text.clone(),
-                        entity_type: "https://agentos.ontology/code/Import".to_string(),
+                        entity_type: "https://agent-os.org/ontology/code/Import".to_string(),
                         description: Some(use_text),
                         properties: HashMap::new(),
                         source_location: Some(format!(
@@ -606,7 +606,7 @@ impl CodeAstExtractor {
                 relations.push(AstRelation {
                     source: caller_id.to_string(),
                     target: callee_id,
-                    relation: "https://agentos.ontology/code/calls".to_string(),
+                    relation: "https://agent-os.org/ontology/code/calls".to_string(),
                 });
             }
         }
@@ -655,7 +655,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Function".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Function".to_string(),
                             description: Some(format!("def {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -677,7 +677,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Class".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Class".to_string(),
                             description: Some(format!("class {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -697,7 +697,7 @@ impl CodeAstExtractor {
                                     relations.push(AstRelation {
                                         source: id.clone(),
                                         target: parent_id,
-                                        relation: "https://agentos.ontology/code/inherits"
+                                        relation: "https://agent-os.org/ontology/code/inherits"
                                             .to_string(),
                                     });
                                 }
@@ -716,7 +716,7 @@ impl CodeAstExtractor {
                     entities.push(AstEntity {
                         id: id.clone(),
                         label: import_text.clone(),
-                        entity_type: "https://agentos.ontology/code/Import".to_string(),
+                        entity_type: "https://agent-os.org/ontology/code/Import".to_string(),
                         description: Some(import_text),
                         properties: HashMap::new(),
                         source_location: Some(format!(
@@ -778,7 +778,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Function".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Function".to_string(),
                             description: Some(format!("function {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -805,7 +805,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Class".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Class".to_string(),
                             description: Some(format!("class {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -824,7 +824,7 @@ impl CodeAstExtractor {
                                     relations.push(AstRelation {
                                         source: id.clone(),
                                         target: parent_id,
-                                        relation: "https://agentos.ontology/code/inherits"
+                                        relation: "https://agent-os.org/ontology/code/inherits"
                                             .to_string(),
                                     });
                                 }
@@ -844,7 +844,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Method".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Method".to_string(),
                             description: Some(format!("method {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -866,7 +866,7 @@ impl CodeAstExtractor {
                     entities.push(AstEntity {
                         id: id.clone(),
                         label: import_text.clone(),
-                        entity_type: "https://agentos.ontology/code/Import".to_string(),
+                        entity_type: "https://agent-os.org/ontology/code/Import".to_string(),
                         description: Some(import_text),
                         properties: HashMap::new(),
                         source_location: Some(format!(
@@ -892,7 +892,7 @@ impl CodeAstExtractor {
                             entities.push(AstEntity {
                                 id: id.clone(),
                                 label: name.clone(),
-                                entity_type: "https://agentos.ontology/code/Function".to_string(),
+                                entity_type: "https://agent-os.org/ontology/code/Function".to_string(),
                                 description: Some(format!("const {} = () => ...", name)),
                                 properties: HashMap::new(),
                                 source_location: Some(format!(
@@ -916,7 +916,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Interface".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Interface".to_string(),
                             description: Some(format!("interface {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -935,7 +935,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/TypeAlias".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/TypeAlias".to_string(),
                             description: Some(format!("type {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -998,7 +998,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Function".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Function".to_string(),
                             description: Some(format!("func {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -1029,7 +1029,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Method".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Method".to_string(),
                             description: Some(format!("method {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -1051,9 +1051,9 @@ impl CodeAstExtractor {
                                     .map(|t| t.kind().to_string())
                                     .unwrap_or_default();
                                 let entity_type = match type_kind.as_str() {
-                                    "struct_type" => "https://agentos.ontology/code/Struct",
-                                    "interface_type" => "https://agentos.ontology/code/Interface",
-                                    _ => "https://agentos.ontology/code/Type",
+                                    "struct_type" => "https://agent-os.org/ontology/code/Struct",
+                                    "interface_type" => "https://agent-os.org/ontology/code/Interface",
+                                    _ => "https://agent-os.org/ontology/code/Type",
                                 };
                                 let id = Self::make_id(
                                     "type",
@@ -1088,7 +1088,7 @@ impl CodeAstExtractor {
                     entities.push(AstEntity {
                         id: id.clone(),
                         label: import_text.clone(),
-                        entity_type: "https://agentos.ontology/code/Import".to_string(),
+                        entity_type: "https://agent-os.org/ontology/code/Import".to_string(),
                         description: Some(import_text),
                         properties: HashMap::new(),
                         source_location: Some(format!(
@@ -1146,9 +1146,9 @@ impl CodeAstExtractor {
                     if let Some(name_node) = node.child_by_field_name("name") {
                         let name = Self::node_text(&name_node, source).to_string();
                         let entity_type = match node.kind() {
-                            "enum_declaration" => "https://agentos.ontology/code/Enum",
-                            "record_declaration" => "https://agentos.ontology/code/Record",
-                            _ => "https://agentos.ontology/code/Class",
+                            "enum_declaration" => "https://agent-os.org/ontology/code/Enum",
+                            "record_declaration" => "https://agent-os.org/ontology/code/Record",
+                            _ => "https://agent-os.org/ontology/code/Class",
                         };
                         let id =
                             Self::make_id("class", file_path, &name, node.start_position().row + 1);
@@ -1175,7 +1175,7 @@ impl CodeAstExtractor {
                             relations.push(AstRelation {
                                 source: id.clone(),
                                 target: parent_id,
-                                relation: "https://agentos.ontology/code/inherits".to_string(),
+                                relation: "https://agent-os.org/ontology/code/inherits".to_string(),
                             });
                         }
 
@@ -1189,7 +1189,7 @@ impl CodeAstExtractor {
                                     relations.push(AstRelation {
                                         source: id.clone(),
                                         target: iface_id,
-                                        relation: "https://agentos.ontology/code/implements"
+                                        relation: "https://agent-os.org/ontology/code/implements"
                                             .to_string(),
                                     });
                                 }
@@ -1209,7 +1209,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Interface".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Interface".to_string(),
                             description: Some(format!("interface {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -1232,7 +1232,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Method".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Method".to_string(),
                             description: Some(format!("method {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -1262,7 +1262,7 @@ impl CodeAstExtractor {
                     entities.push(AstEntity {
                         id: id.clone(),
                         label: import_text.clone(),
-                        entity_type: "https://agentos.ontology/code/Import".to_string(),
+                        entity_type: "https://agent-os.org/ontology/code/Import".to_string(),
                         description: Some(import_text),
                         properties: HashMap::new(),
                         source_location: Some(format!(
@@ -1336,7 +1336,7 @@ impl CodeAstExtractor {
                         entities.push(AstEntity {
                             id: id.clone(),
                             label: name.clone(),
-                            entity_type: "https://agentos.ontology/code/Function".to_string(),
+                            entity_type: "https://agent-os.org/ontology/code/Function".to_string(),
                             description: Some(format!("function {}", name)),
                             properties: HashMap::new(),
                             source_location: Some(format!(
@@ -1359,9 +1359,9 @@ impl CodeAstExtractor {
                     if let Some(name_node) = node.child_by_field_name("name") {
                         let name = Self::node_text(&name_node, source).to_string();
                         let entity_type = if node.kind() == "class_specifier" {
-                            "https://agentos.ontology/code/Class"
+                            "https://agent-os.org/ontology/code/Class"
                         } else {
-                            "https://agentos.ontology/code/Struct"
+                            "https://agent-os.org/ontology/code/Struct"
                         };
                         let id =
                             Self::make_id("class", file_path, &name, node.start_position().row + 1);
@@ -1394,7 +1394,7 @@ impl CodeAstExtractor {
                     entities.push(AstEntity {
                         id: id.clone(),
                         label: include_text.clone(),
-                        entity_type: "https://agentos.ontology/code/Import".to_string(),
+                        entity_type: "https://agent-os.org/ontology/code/Import".to_string(),
                         description: Some(include_text),
                         properties: HashMap::new(),
                         source_location: Some(format!(
@@ -1453,7 +1453,7 @@ impl CodeAstExtractor {
                 relations.push(AstRelation {
                     source: caller_id.to_string(),
                     target: callee_id,
-                    relation: "https://agentos.ontology/code/calls".to_string(),
+                    relation: "https://agent-os.org/ontology/code/calls".to_string(),
                 });
             }
         }
@@ -1918,7 +1918,7 @@ class Child(Base):
         CodeAstExtractor::extract_incremental(path_str, graph, &store).unwrap();
 
         let count_sparql = format!(
-            "SELECT (COUNT(DISTINCT ?s) AS ?count) WHERE {{ GRAPH <{}> {{ ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://agentos.ontology/code/Function> . }} }}",
+            "SELECT (COUNT(DISTINCT ?s) AS ?count) WHERE {{ GRAPH <{}> {{ ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://agent-os.org/ontology/code/Function> . }} }}",
             graph
         );
         let results = store.query_sparql(&count_sparql, None).unwrap();

--- a/src/knowledge_graph/extractor.rs
+++ b/src/knowledge_graph/extractor.rs
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn test_validate_extraction_valid() {
-        let json = r#"{"nodes": [{"id": "a", "node_type": "https://agentos.ontology/core/Person", "label": "Alice", "properties": {}}], "edges": [{"source": "a", "target": "b", "relation": "https://agentos.ontology/business/worksFor", "properties": {}}]}"#;
+        let json = r#"{"nodes": [{"id": "a", "node_type": "https://agent-os.org/ontology/core/Person", "label": "Alice", "properties": {}}], "edges": [{"source": "a", "target": "b", "relation": "https://agent-os.org/ontology/biz/worksFor", "properties": {}}]}"#;
         let result = KnowledgeExtractor::validate_extraction(json);
         assert!(result.is_ok());
         let output = result.unwrap();
@@ -425,10 +425,10 @@ mod tests {
 
     #[test]
     fn test_build_extraction_prompt() {
-        let vocab = "## Available entity types\n- IRI: https://agentos.ontology/core/Person | name: Person | Represents a person";
+        let vocab = "## Available entity types\n- IRI: https://agent-os.org/ontology/core/Person | name: Person | Represents a person";
         let prompt = KnowledgeExtractor::build_extraction_prompt("test text", vocab);
         assert!(prompt.contains("knowledge graph extraction expert"));
-        assert!(prompt.contains("https://agentos.ontology/core/Person"));
+        assert!(prompt.contains("https://agent-os.org/ontology/core/Person"));
         assert!(prompt.contains("test text"));
         assert!(prompt.contains("nodes"));
         assert!(prompt.contains("edges"));

--- a/src/knowledge_graph/ontology.rs
+++ b/src/knowledge_graph/ontology.rs
@@ -4,16 +4,16 @@ use std::sync::OnceLock;
 static BUILT_IN_ONTOLOGY: OnceLock<Vec<OntologyTerm>> = OnceLock::new();
 
 fn core(s: &str) -> String {
-    format!("https://agentos.ontology/core/{}", s)
+    format!("https://agent-os.org/ontology/core/{}", s)
 }
 fn eng(s: &str) -> String {
-    format!("https://agentos.ontology/eng/{}", s)
+    format!("https://agent-os.org/ontology/eng/{}", s)
 }
 fn code(s: &str) -> String {
-    format!("https://agentos.ontology/code/{}", s)
+    format!("https://agent-os.org/ontology/code/{}", s)
 }
 fn biz(s: &str) -> String {
-    format!("https://agentos.ontology/biz/{}", s)
+    format!("https://agent-os.org/ontology/biz/{}", s)
 }
 
 pub struct OntologyManager {

--- a/src/knowledge_graph/rdf_mapper.rs
+++ b/src/knowledge_graph/rdf_mapper.rs
@@ -97,7 +97,7 @@ impl RdfMapper {
                     let predicate = if key.contains('/') || key.contains('#') || key.contains(':') {
                         key.clone()
                     } else {
-                        format!("https://agentos.ontology/meta/{}", key)
+                        format!("https://agent-os.org/ontology/meta/{}", key)
                     };
                     quads.push(RdfQuad {
                         subject: iri.clone(),
@@ -286,7 +286,7 @@ mod tests {
 
         let age_quad = quads
             .iter()
-            .find(|q| q.predicate == "https://agentos.ontology/meta/age")
+            .find(|q| q.predicate == "https://agent-os.org/ontology/meta/age")
             .unwrap();
         assert_eq!(
             age_quad.object,
@@ -298,7 +298,7 @@ mod tests {
 
         let active_quad = quads
             .iter()
-            .find(|q| q.predicate == "https://agentos.ontology/meta/active")
+            .find(|q| q.predicate == "https://agent-os.org/ontology/meta/active")
             .unwrap();
         assert_eq!(
             active_quad.object,

--- a/src/knowledge_graph/store.rs
+++ b/src/knowledge_graph/store.rs
@@ -73,7 +73,7 @@ impl KnowledgeGraphStore {
             .map_err(|e| format!("SPARQL DELETE failed: {}", e))?;
 
         let related_delete = format!(
-            "DELETE WHERE {{ GRAPH <{}> {{ ?s <https://agentos.ontology/code/contains> <{}> . }} }}",
+            "DELETE WHERE {{ GRAPH <{}> {{ ?s <https://agent-os.org/ontology/code/contains> <{}> . }} }}",
             graph, subject_iri
         );
         let _ = self.store.update(&related_delete);
@@ -125,7 +125,7 @@ impl KnowledgeGraphStore {
     /// an incremental re-extraction.
     #[allow(deprecated)]
     pub fn delete_code_file_subgraph(&self, file_iri: &str, graph: &str) -> Result<usize, String> {
-        let contains = "https://agentos.ontology/code/contains";
+        let contains = "https://agent-os.org/ontology/code/contains";
         let query = format!(
             "SELECT DISTINCT ?node WHERE {{ GRAPH <{}> {{ <{}> <{}> ?node . }} }}",
             graph, file_iri, contains
@@ -248,7 +248,7 @@ impl KnowledgeGraphStore {
                 let type_iri = if t.contains("://") {
                     t.to_string()
                 } else {
-                    format!("http://agent-os.org/ontology/{}", t)
+                    format!("https://agent-os.org/ontology/core/{}", t)
                 };
                 format!(
                     "?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{}> .",

--- a/src/memory/l2_blackboard.rs
+++ b/src/memory/l2_blackboard.rs
@@ -307,7 +307,7 @@ impl Blackboard {
                             let type_uri = if t.contains("://") {
                                 format!("<{}>", t)
                             } else {
-                                format!("<http://agent-os.org/ontology/{}>", t)
+                                format!("<https://agent-os.org/ontology/core/{}>", t)
                             };
                             triples.push(format!("{} a {} .", subject, type_uri));
                         } else if let Some(arr) = value.as_array() {
@@ -315,7 +315,7 @@ impl Blackboard {
                                 let type_uri = if t.contains("://") {
                                     format!("<{}>", t)
                                 } else {
-                                    format!("<http://agent-os.org/ontology/{}>", t)
+                                    format!("<https://agent-os.org/ontology/core/{}>", t)
                                 };
                                 triples.push(format!("{} a {} .", subject, type_uri));
                             }
@@ -325,7 +325,7 @@ impl Blackboard {
                 }
 
                 let escaped_key = key.replace(' ', "_");
-                let predicate = format!("<http://agent-os.org/ontology/{}>", escaped_key);
+                let predicate = format!("<https://agent-os.org/ontology/core/{}>", escaped_key);
 
                 match value {
                     serde_json::Value::String(s) => {
@@ -1342,7 +1342,7 @@ impl Blackboard {
                 if t.contains("://") {
                     format!("<{}>", t)
                 } else {
-                    format!("<http://agent-os.org/ontology/{}>", t)
+                    format!("<https://agent-os.org/ontology/core/{}>", t)
                 }
             })
             .collect();
@@ -2856,7 +2856,7 @@ mod tests {
         bb.write_node_to_graph(
             "iri://workspace/file/main.rs",
             json_ld,
-            "http://agent-os.org/workspace",
+            "https://agent-os.org/workspace",
             &config,
         )
         .unwrap();

--- a/src/memory/l3_projection.rs
+++ b/src/memory/l3_projection.rs
@@ -134,7 +134,7 @@ impl ProjectionEngine {
                 max_nodes: 20,
                 sparql_template: Some(
                     r#"
-                PREFIX ex: <http://agent-os.org/ontology/>
+                PREFIX ex: <https://agent-os.org/ontology/core/>
                 CONSTRUCT {
                     ?node ex:summary ?summary .
                     ?node ex:status ?status .
@@ -153,7 +153,7 @@ impl ProjectionEngine {
                 params: vec![],
                 jsonld_frame: Some(
                     FrameTemplate::new(serde_json::json!({
-                        "agent": "https://agent-harness.os/agent#"
+                        "agent": "https://agent-os.org/ontology/agent#"
                     }))
                     .with_include_properties(vec!["summary".to_string(), "status".to_string()])
                     .with_max_depth(1),
@@ -187,7 +187,7 @@ impl ProjectionEngine {
                 max_nodes: 10,
                 sparql_template: Some(
                     r#"
-                PREFIX ex: <http://agent-os.org/ontology/>
+                PREFIX ex: <https://agent-os.org/ontology/core/>
                 CONSTRUCT {
                     ?task ex:goal ?goal .
                     ?task ex:constraints ?constraints .
@@ -207,8 +207,8 @@ impl ProjectionEngine {
                 params: vec!["task_iri".to_string()],
                 jsonld_frame: Some(
                     FrameTemplate::new(serde_json::json!({
-                        "exec": "https://agent-harness.os/exec#",
-                        "task": "https://agent-harness.os/task#"
+                        "exec": "https://agent-os.org/ontology/exec#",
+                        "task": "https://agent-os.org/ontology/task#"
                     }))
                     .with_embed_rule("task:subTasks".to_string(), EmbedDirective::Always)
                     .with_embed_rule("exec:assignedTo".to_string(), EmbedDirective::Link)
@@ -235,7 +235,7 @@ impl ProjectionEngine {
                 max_nodes: 10,
                 sparql_template: Some(
                     r#"
-                PREFIX ex: <http://agent-os.org/ontology/>
+                PREFIX ex: <https://agent-os.org/ontology/core/>
                 CONSTRUCT {
                     ?node ex:instructions ?instructions .
                     ?node ex:dependencies ?deps .
@@ -255,8 +255,8 @@ impl ProjectionEngine {
                 params: vec!["plan_iri".to_string()],
                 jsonld_frame: Some(
                     FrameTemplate::new(serde_json::json!({
-                        "exec": "https://agent-harness.os/exec#",
-                        "task": "https://agent-harness.os/task#"
+                        "exec": "https://agent-os.org/ontology/exec#",
+                        "task": "https://agent-os.org/ontology/task#"
                     }))
                     .with_embed_rule("task:inputData".to_string(), EmbedDirective::Always)
                     .with_embed_rule("task:resources".to_string(), EmbedDirective::Link)
@@ -302,8 +302,8 @@ impl ProjectionEngine {
                 params: vec!["artifact_iri".to_string()],
                 jsonld_frame: Some(
                     FrameTemplate::new(serde_json::json!({
-                        "exec": "https://agent-harness.os/exec#",
-                        "task": "https://agent-harness.os/task#"
+                        "exec": "https://agent-os.org/ontology/exec#",
+                        "task": "https://agent-os.org/ontology/task#"
                     }))
                     .with_embed_rule("exec:results".to_string(), EmbedDirective::Always)
                     .with_embed_rule("exec:validationRules".to_string(), EmbedDirective::Always)
@@ -342,8 +342,8 @@ impl ProjectionEngine {
                 params: vec!["review_iri".to_string()],
                 jsonld_frame: Some(
                     FrameTemplate::new(serde_json::json!({
-                        "exec": "https://agent-harness.os/exec#",
-                        "task": "https://agent-harness.os/task#"
+                        "exec": "https://agent-os.org/ontology/exec#",
+                        "task": "https://agent-os.org/ontology/task#"
                     }))
                     .with_embed_rule("exec:reviewResults".to_string(), EmbedDirective::Always)
                     .with_embed_rule("exec:alternatives".to_string(), EmbedDirective::Link)
@@ -431,7 +431,7 @@ impl ProjectionEngine {
                 max_nodes: 20,
                 sparql_template: Some(
                     r#"
-        PREFIX task: <https://pdca-agent.org/ontology/task#>
+        PREFIX task: <https://agent-os.org/ontology/task#>
         CONSTRUCT {
             ?node task:what ?what .
             ?node task:why ?why .
@@ -451,7 +451,7 @@ impl ProjectionEngine {
                 params: vec![],
                 jsonld_frame: Some(
                     FrameTemplate::new(serde_json::json!({
-                        "task": "https://pdca-agent.org/ontology/task#"
+                        "task": "https://agent-os.org/ontology/task#"
                     }))
                     .with_include_properties(vec![
                         "task:what".to_string(),
@@ -828,17 +828,17 @@ impl ProjectionEngine {
             return "@type".to_string();
         }
 
-        if let Some(prop) = predicate.strip_prefix("http://agent-os.org/prop/") {
+        if let Some(prop) = predicate.strip_prefix("https://agent-os.org/ontology/core/") {
             return prop.replace('_', " ");
         }
 
-        if let Some(prop) = predicate.strip_prefix("http://agent-os.org/ontology/") {
+        if let Some(prop) = predicate.strip_prefix("https://agent-os.org/ontology/core/") {
             return prop.to_string();
         }
 
         for prefix in &[
-            "https://agent-harness.os/task#",
-            "https://agent-harness.os/exec#",
+            "https://agent-os.org/ontology/task#",
+            "https://agent-os.org/ontology/exec#",
         ] {
             if let Some(prop) = predicate.strip_prefix(prefix) {
                 return prop.to_string();
@@ -1196,7 +1196,7 @@ impl ProjectionEngine {
         let mut current_tokens = 0;
 
         let default_frame = FrameTemplate::new(serde_json::json!({
-            "agent": "https://agent-harness.os/agent#"
+            "agent": "https://agent-os.org/ontology/agent#"
         }))
         .with_max_depth(3);
 
@@ -1225,7 +1225,7 @@ impl ProjectionEngine {
         projection.insert(
             "@context".to_string(),
             serde_json::json!({
-                "agent": "https://agent-harness.os/agent#"
+                "agent": "https://agent-os.org/ontology/agent#"
             }),
         );
         projection.insert("task_iri".to_string(), Value::String(task_iri.to_string()));
@@ -1370,7 +1370,7 @@ mod tests {
         );
 
         let frame = FrameTemplate::new(serde_json::json!({
-            "task": "https://agent-harness.os/task#"
+            "task": "https://agent-os.org/ontology/task#"
         }))
         .with_include_properties(vec!["summary".to_string(), "status".to_string()])
         .with_max_depth(2);

--- a/src/memory/memory_manager.rs
+++ b/src/memory/memory_manager.rs
@@ -242,7 +242,7 @@ impl MemoryManager {
         // Use task-prefixed IRI so extract_task_iri maps this node to the correct task
         let node_iri = format!("{}/session/{}", task_iri, summary.session_id);
         let json_ld = serde_json::json!({
-            "@context": "https://pdca-agent.org/context/memory",
+            "@context": "https://agent-os.org/context/memory",
             "@id": &node_iri,
             "@type": "SessionSummary",
             "session_id": summary.session_id,
@@ -272,13 +272,13 @@ impl MemoryManager {
             for fc in &a.files_created {
                 produces.push(serde_json::json!({
                     "@id": format!("iri://file/{}", fc.path.replace('/', "_")),
-                    "@type": "https://agentos.ontology/core/File",
-                    "https://agentos.ontology/core/filePath": fc.path,
+                    "@type": "https://agent-os.org/ontology/core/File",
+                    "https://agent-os.org/ontology/core/filePath": fc.path,
                 }));
             }
         }
         let json_ld = serde_json::json!({
-            "@context": {"aos": "https://agentos.ontology/core/"},
+            "@context": {"aos": "https://agent-os.org/ontology/core/"},
             "@id": task_id,
             "@type": "aos:Task",
             "aos:hasStatus": "completed",
@@ -364,7 +364,7 @@ impl MemoryManager {
                     .map(|f| f.name.clone())
                     .collect();
                 let result = serde_json::json!({
-                    "@context": "https://pdca-agent.org/context/projection",
+                    "@context": "https://agent-os.org/context/projection",
                     "note": "Async runtime not available, returning frame list",
                     "available_frames": frames,
                 })

--- a/src/memory/scheduler.rs
+++ b/src/memory/scheduler.rs
@@ -169,7 +169,7 @@ impl MemoryScheduler {
         let config = crate::CoreConfig::default();
 
         let json_ld = serde_json::json!({
-            "@context": "https://pdca-agent.org/context/memory",
+            "@context": "https://agent-os.org/context/memory",
             "@id": format!("iri://memory/{}", uuid::Uuid::new_v4().hyphenated()),
             "@type": "SessionSummary",
             "session_id": summary.session_id,

--- a/src/memory/unified_graph.rs
+++ b/src/memory/unified_graph.rs
@@ -79,7 +79,7 @@ impl UnifiedGraphStore {
         info!("Initializing Unified Oxigraph Store (memory)");
         Ok(Self {
             store: Arc::new(Store::new()?),
-            default_graph: "http://agent-os.org/graph/default".to_string(),
+            default_graph: "https://agent-os.org/graph/default".to_string(),
         })
     }
 
@@ -87,7 +87,7 @@ impl UnifiedGraphStore {
         info!(path = %path.as_ref().display(), "Initializing persistent Unified Oxigraph Store");
         Ok(Self {
             store: Arc::new(Store::open(path)?),
-            default_graph: "http://agent-os.org/graph/default".to_string(),
+            default_graph: "https://agent-os.org/graph/default".to_string(),
         })
     }
 
@@ -103,7 +103,7 @@ impl UnifiedGraphStore {
     pub fn with_shared_store(store: Arc<Store>) -> Self {
         Self {
             store,
-            default_graph: "http://agent-os.org/graph/default".to_string(),
+            default_graph: "https://agent-os.org/graph/default".to_string(),
         }
     }
 

--- a/src/skill_graph/types.rs
+++ b/src/skill_graph/types.rs
@@ -790,7 +790,7 @@ impl SkillGraphNode {
             self.maturity,
         );
 
-        format!("PREFIX skill: <https://agent-harness.os/skill#>\nINSERT DATA {{ GRAPH <{}> {{ {} }} }}", graph, triples)
+        format!("PREFIX skill: <https://agent-os.org/ontology/skill#>\nINSERT DATA {{ GRAPH <{}> {{ {} }} }}", graph, triples)
     }
 
     pub fn to_json_ld(&self) -> serde_json::Value {
@@ -808,7 +808,7 @@ impl SkillGraphNode {
 
         json!({
             "@context": {
-                "skill": "https://agent-harness.os/skill#",
+                "skill": "https://agent-os.org/ontology/skill#",
                 "schema": "https://schema.org/"
             },
             "@id": self.skill_iri,

--- a/src/tools/result_router/graphify.rs
+++ b/src/tools/result_router/graphify.rs
@@ -108,7 +108,7 @@ impl GraphifyEngine {
                                     let child_id = format!("{}_{}", id, key);
                                     let child_label = Self::extract_label(child, &child_id);
                                     let child_type = format!(
-                                        "https://agentos.ontology/tool-result/{}_{}",
+                                        "https://agent-os.org/ontology/tool-result/{}_{}",
                                         Self::to_iri_short(&node_type),
                                         key
                                     );
@@ -148,7 +148,7 @@ impl GraphifyEngine {
                                                 &arr_item_id,
                                             );
                                             let arr_item_type = format!(
-                                                "https://agentos.ontology/tool-result/{}_{}_item",
+                                                "https://agent-os.org/ontology/tool-result/{}_{}_item",
                                                 Self::to_iri_short(&node_type),
                                                 key
                                             );
@@ -200,7 +200,7 @@ impl GraphifyEngine {
                         let id = format!("{}_{}", call_id, idx);
                         nodes.push(NodeDef {
                             id: id.clone(),
-                            node_type: "https://agentos.ontology/tool-result/ScalarItem"
+                            node_type: "https://agent-os.org/ontology/tool-result/ScalarItem"
                                 .to_string(),
                             label: format!("Item {}", idx),
                             description: None,
@@ -216,7 +216,7 @@ impl GraphifyEngine {
             Value::Object(obj) => {
                 let id = format!("{}_root", call_id);
                 let label = Self::extract_label(obj, &id);
-                let node_type = "https://agentos.ontology/tool-result/RootObject".to_string();
+                let node_type = "https://agent-os.org/ontology/tool-result/RootObject".to_string();
 
                 let mut properties = HashMap::new();
                 let mut child_edges = Vec::new();
@@ -228,7 +228,7 @@ impl GraphifyEngine {
                                 let child_id = format!("{}_{}", id, key);
                                 let child_label = Self::extract_label(child, &child_id);
                                 let child_type =
-                                    format!("https://agentos.ontology/tool-result/Child_{}", key);
+                                    format!("https://agent-os.org/ontology/tool-result/Child_{}", key);
 
                                 let mut child_props = HashMap::new();
                                 for (ck, cv) in child {
@@ -262,7 +262,7 @@ impl GraphifyEngine {
                                     let arr_item_label =
                                         Self::extract_label(child_obj, &arr_item_id);
                                     let arr_item_type = format!(
-                                        "https://agentos.ontology/tool-result/{}_item",
+                                        "https://agent-os.org/ontology/tool-result/{}_item",
                                         key
                                     );
 
@@ -310,7 +310,7 @@ impl GraphifyEngine {
             _ => {
                 nodes.push(NodeDef {
                     id: format!("{}_value", call_id),
-                    node_type: "https://agentos.ontology/tool-result/ScalarValue".to_string(),
+                    node_type: "https://agent-os.org/ontology/tool-result/ScalarValue".to_string(),
                     label: "Value".to_string(),
                     description: None,
                     properties: {
@@ -352,14 +352,14 @@ impl GraphifyEngine {
                 return Self::to_iri(s);
             }
         }
-        "https://agentos.ontology/tool-result/Entity".to_string()
+        "https://agent-os.org/ontology/tool-result/Entity".to_string()
     }
 
     fn to_iri(s: &str) -> String {
         if s.starts_with("http://") || s.starts_with("https://") || s.starts_with("iri://") {
             s.to_string()
         } else {
-            format!("https://agentos.ontology/tool-result/{}", s)
+            format!("https://agent-os.org/ontology/tool-result/{}", s)
         }
     }
 
@@ -377,7 +377,7 @@ impl GraphifyEngine {
                 {
                     key
                 } else {
-                    format!("https://agentos.ontology/property/{}", key)
+                    format!("https://agent-os.org/ontology/property/{}", key)
                 };
                 normalized.insert(iri_key, value);
             }
@@ -389,7 +389,7 @@ impl GraphifyEngine {
                 && !edge.relation.starts_with("https://")
                 && !edge.relation.starts_with("iri://")
             {
-                edge.relation = format!("https://agentos.ontology/relation/{}", edge.relation);
+                edge.relation = format!("https://agent-os.org/ontology/relation/{}", edge.relation);
             }
         }
     }

--- a/src/tools/sharing.rs
+++ b/src/tools/sharing.rs
@@ -114,7 +114,7 @@ impl SharedReference {
 
     pub fn to_json_ld(&self) -> Value {
         let mut doc = serde_json::json!({
-            "@context": "https://pdca-agent.org/share",
+            "@context": "https://agent-os.org/share",
             "@id": self.share_id,
             "@type": "SharedReference",
             "source_agent": self.source_agent_iri,
@@ -177,7 +177,7 @@ impl ShareRequest {
 
     pub fn to_json_ld(&self) -> Value {
         let mut doc = serde_json::json!({
-            "@context": "https://pdca-agent.org/share",
+            "@context": "https://agent-os.org/share",
             "@id": format!("iri://share/request/{}", self.request_id),
             "@type": "ShareRequest",
             "request_id": self.request_id,
@@ -241,7 +241,7 @@ impl ShareResponse {
 
     pub fn to_json_ld(&self) -> Value {
         serde_json::json!({
-            "@context": "https://pdca-agent.org/share",
+            "@context": "https://agent-os.org/share",
             "@id": format!("iri://share/response/{}", self.request_id),
             "@type": "ShareResponse",
             "request_id": self.request_id,
@@ -480,7 +480,7 @@ impl ContextInjector {
         }
 
         serde_json::json!({
-            "@context": "https://pdca-agent.org/context/injection",
+            "@context": "https://agent-os.org/context/injection",
             "@type": "ContextInjection",
             "target_agent": target_agent_iri,
             "task_iri": task_iri,
@@ -508,7 +508,7 @@ impl ContextInjector {
         );
 
         serde_json::json!({
-            "@context": "https://pdca-agent.org/context/handoff",
+            "@context": "https://agent-os.org/context/handoff",
             "@type": "AgentHandoff",
             "from_agent": from_agent_iri,
             "to_agent": to_agent_iri,

--- a/src/tools/skill_registry.rs
+++ b/src/tools/skill_registry.rs
@@ -966,7 +966,7 @@ impl SkillRegistry {
     pub fn sync_to_oxigraph(&self, blackboard: &Blackboard) -> Result<usize, CoreError> {
         use std::fmt::Write;
         let skills = self.list_all_skills();
-        let mut sparql = String::from("PREFIX skill: <https://agent-harness.os/skill#>\n");
+        let mut sparql = String::from("PREFIX skill: <https://agent-os.org/ontology/skill#>\n");
         for s in &skills {
             let iri = &s.skill_iri;
             let name = s.name.replace('\\', "\\\\").replace('\'', "\\'");
@@ -997,7 +997,7 @@ impl SkillRegistry {
     ) -> Result<Vec<SkillMeta>, CoreError> {
         let safe_query = query.replace('\'', "\\'");
         let sparql = format!(
-            "PREFIX skill: <https://agent-harness.os/skill#>
+            "PREFIX skill: <https://agent-os.org/ontology/skill#>
              SELECT ?iri ?name ?desc ?cat ?sec WHERE {{
                GRAPH <system:skills> {{
                  ?iri a skill:RegisteredSkill ;
@@ -1103,7 +1103,7 @@ impl SkillRegistry {
             .unwrap_or_default();
         context_map.insert(
             "schema".to_string(),
-            serde_json::json!("https://agent-harness.os/schema#"),
+            serde_json::json!("https://agent-os.org/ontology/schema#"),
         );
 
         let mut input_props = serde_json::Map::new();

--- a/src/tools/tool_executor/builtins.rs
+++ b/src/tools/tool_executor/builtins.rs
@@ -1809,7 +1809,7 @@ pub(super) async fn execute_ontology_register(
         }
         quads.push(RdfQuad {
             subject: iri,
-            predicate: "https://agentos.ontology/meta/termType".to_string(),
+            predicate: "https://agent-os.org/ontology/meta/termType".to_string(),
             object: RdfValue::Literal(term_type),
             graph: Some(graph.to_string()),
         });

--- a/tests/fixtures/skills/axure-to-vue2-skill/SKILL.md
+++ b/tests/fixtures/skills/axure-to-vue2-skill/SKILL.md
@@ -1,0 +1,21 @@
+# Axure to Vue2 Skill
+
+将 Axure 导出的 HTML5 原型自动转换为可运行的 Vue2 工程代码。
+
+## 参数
+
+- axure_export_dir: Axure 导出 HTML5 目录路径
+- output_dir: Vue2 项目输出目录
+- viewport_width: 视口宽度，可选
+
+## 步骤
+
+- 解析 Axure 导出的 HTML5 结构与样式
+- 将页面元素映射为 Vue2 单文件组件
+- 生成路由、状态与静态资源并输出到目标目录
+
+## 标签
+
+- axure
+- vue2
+- codegen

--- a/tests/fixtures/skills/axure-vue2-refactor/SKILL.md
+++ b/tests/fixtures/skills/axure-vue2-refactor/SKILL.md
@@ -1,0 +1,23 @@
+# Axure Vue2 Refactor Skill
+
+对由 Axure 转换生成的 Vue2 组件进行结构化重构，提升代码质量与可维护性。
+
+## 参数
+
+- vue_component_path: 待重构的 Vue2 组件路径
+- refactor_options: 重构选项配置，可选
+
+## 步骤
+
+- 分析组件的模板、脚本与样式结构
+- 抽取可复用的子组件与公共逻辑
+- 规范化命名与目录结构
+- 拆分过长的方法与计算属性
+- 补充 props 与事件类型约束
+- 输出重构后的组件并生成变更说明
+
+## 标签
+
+- axure
+- vue2
+- refactor

--- a/tests/integration_mod/test_jsonld.rs
+++ b/tests/integration_mod/test_jsonld.rs
@@ -449,8 +449,8 @@ fn test_sparql_query_on_jsonld_nodes() {
 
     let sparql = r#"
         SELECT ?s ?status WHERE {
-        ?s a <http://agent-os.org/ontology/Task> .
-        ?s <http://agent-os.org/ontology/status> ?status .
+        ?s a <https://agent-os.org/ontology/core/Task> .
+        ?s <https://agent-os.org/ontology/core/status> ?status .
         }
     "#;
 
@@ -624,7 +624,7 @@ fn test_performance_sparql_query() {
     }
 
     let start = Instant::now();
-    let sparql = "SELECT ?s WHERE { ?s a <http://agent-os.org/ontology/TypeA> }";
+    let sparql = "SELECT ?s WHERE { ?s a <https://agent-os.org/ontology/core/TypeA> }";
     let results = blackboard.query(sparql).unwrap();
     let query_time = start.elapsed().as_millis();
 
@@ -699,7 +699,7 @@ fn test_bug3_type_namespace_fix() {
     blackboard.flush_oxigraph();
 
     let sparql_ontology = r#"
-        PREFIX ex: <http://agent-os.org/ontology/>
+        PREFIX ex: <https://agent-os.org/ontology/core/>
         SELECT ?s ?summary WHERE {
             ?s a ex:Task .
             ?s ex:summary ?summary .
@@ -709,7 +709,7 @@ fn test_bug3_type_namespace_fix() {
     assert!(
         !results.is_empty(),
         "Bug 3 FAIL: SPARQL query with ex:Task (ontology/) returned 0 results. \
-         write_node with @type='Task' should store as <http://agent-os.org/ontology/Task>"
+         write_node with @type='Task' should store as <https://agent-os.org/ontology/core/Task>"
     );
     println!(
         "[Bug 3] ontology/ SPARQL returned {} result(s)",
@@ -718,7 +718,7 @@ fn test_bug3_type_namespace_fix() {
     println!("[Bug 3] First result: {:?}", results[0]);
 
     // Step 3: Negative test — type/ should NOT exist
-    let sparql_type = "SELECT ?s WHERE { ?s a <http://agent-os.org/type/Task> } LIMIT 1";
+    let sparql_type = "SELECT ?s WHERE { ?s a <https://agent-os.org/type/Task> } LIMIT 1";
     let old_results = blackboard.query(sparql_type).unwrap();
     assert!(
         old_results.is_empty(),
@@ -798,7 +798,7 @@ fn test_bug1_skill_iri_fix() {
 
     // Step 4: Verify the data via SELECT (data is in named graph system:test_graph)
     use oxigraph::sparql::QueryResults;
-    let verify_sparql = "PREFIX skill: <https://agent-harness.os/skill#>
+    let verify_sparql = "PREFIX skill: <https://agent-os.org/ontology/skill#>
         SELECT ?s WHERE { GRAPH <system:test_graph> { ?s a skill:CognitiveSkill } }";
     let query_results = store.query(verify_sparql).unwrap();
     let solutions: Vec<_> = match query_results {
@@ -815,7 +815,7 @@ fn test_bug1_skill_iri_fix() {
     );
 
     // Step 5: Verify linked usageCount and successRate data
-    let detail_sparql = "PREFIX skill: <https://agent-harness.os/skill#>
+    let detail_sparql = "PREFIX skill: <https://agent-os.org/ontology/skill#>
         SELECT ?usage ?rate WHERE { GRAPH <system:test_graph> { ?s skill:usageCount ?usage ; skill:successRate ?rate } }";
     let detail_results = store.query(detail_sparql).unwrap();
     let detail_solutions: Vec<_> = match detail_results {
@@ -830,7 +830,7 @@ fn test_bug1_skill_iri_fix() {
     println!("[Bug 1] Skill detail data (usageCount, successRate) also confirmed");
 
     // Step 6: Cross-graph query — default graph should NOT have the data
-    let default_sparql = "PREFIX skill: <https://agent-harness.os/skill#>
+    let default_sparql = "PREFIX skill: <https://agent-os.org/ontology/skill#>
         SELECT ?s WHERE { ?s a skill:CognitiveSkill }";
     let default_results = store.query(default_sparql).unwrap();
     let default_solutions: Vec<_> = match default_results {
@@ -854,9 +854,9 @@ fn test_bug2_kg_search_entity_type_fix() {
     let store = KnowledgeGraphStore::new().unwrap();
 
     // Step 1: Insert a quad with type in ontology/ namespace via inner store
-    let insert_sparql = "PREFIX ex: <http://agent-os.org/ontology/>
+    let insert_sparql = "PREFIX ex: <https://agent-os.org/ontology/core/>
         INSERT DATA {
-            GRAPH <http://agent-os.org/graph/test_graph> {
+            GRAPH <https://agent-os.org/graph/test_graph> {
                 <iri://entity/test_entity> a ex:TestEntity .
                 <iri://entity/test_entity> <http://www.w3.org/2000/01/rdf-schema#label> \"Test Entity Label\" .
             }
@@ -878,7 +878,10 @@ fn test_bug2_kg_search_entity_type_fix() {
 
     // Step 3: Search with full IRI still works
     let results_full = store
-        .search_entities("Test", Some("http://agent-os.org/ontology/TestEntity"))
+        .search_entities(
+            "Test",
+            Some("https://agent-os.org/ontology/core/TestEntity"),
+        )
         .unwrap();
     assert!(
         !results_full.is_empty(),
@@ -924,7 +927,7 @@ fn test_bug3_edge_cases() {
         .unwrap();
     blackboard.flush_oxigraph();
 
-    let sparql = r#"PREFIX ex: <http://agent-os.org/ontology/>
+    let sparql = r#"PREFIX ex: <https://agent-os.org/ontology/core/>
         SELECT ?s WHERE { ?s a ex:Urgent }"#;
     let results = blackboard.query(sparql).unwrap();
     assert_eq!(results.len(), 1, "Multi-type: ex:Urgent should match");
@@ -971,7 +974,7 @@ fn test_bug3_edge_cases() {
     }
     blackboard.flush_oxigraph();
 
-    let sparql_bulk = r#"PREFIX ex: <http://agent-os.org/ontology/>
+    let sparql_bulk = r#"PREFIX ex: <https://agent-os.org/ontology/core/>
         SELECT (COUNT(?s) AS ?cnt) WHERE { ?s a ex:BulkNode }"#;
     let bulk_results = blackboard.query(sparql_bulk).unwrap();
     println!("[R2 Bug3-E3] Bulk type query: {:?}", bulk_results);
@@ -1045,7 +1048,7 @@ fn test_bug1_edge_cases() {
     for (link_type, target_iri) in &all_link_types {
         let link_name = format!("{:?}", link_type); // e.g., "Prerequisite"
         let verify = format!(
-            "PREFIX skill: <https://agent-harness.os/skill#>
+            "PREFIX skill: <https://agent-os.org/ontology/skill#>
              SELECT ?s WHERE {{ GRAPH <system:edge_graph> {{ ?s skill:{} <{}> }} }}",
             link_name, target_iri
         );
@@ -1068,7 +1071,7 @@ fn test_bug1_edge_cases() {
     let store2 = oxigraph::store::Store::new().unwrap();
     store2.update(&sparql_special).unwrap();
 
-    let verify_special = r#"PREFIX skill: <https://agent-harness.os/skill#>
+    let verify_special = r#"PREFIX skill: <https://agent-os.org/ontology/skill#>
         SELECT ?name ?desc WHERE { GRAPH <system:special_graph> { ?s skill:name ?name ; skill:description ?desc } }"#;
     let qr = store2.query(verify_special).unwrap();
     let sols: Vec<_> = match qr {
@@ -1104,7 +1107,7 @@ fn test_bug1_edge_cases() {
     let store3 = oxigraph::store::Store::new().unwrap();
     store3.update(&sparql_empty).unwrap();
 
-    let verify_empty = r#"PREFIX skill: <https://agent-harness.os/skill#>
+    let verify_empty = r#"PREFIX skill: <https://agent-os.org/ontology/skill#>
         SELECT ?s WHERE { GRAPH <system:empty_graph> { ?s a skill:CognitiveSkill } }"#;
     let qr = store3.query(verify_empty).unwrap();
     let sols: Vec<_> = match qr {
@@ -1132,10 +1135,10 @@ fn test_bug2_edge_cases() {
         let type_iri = if type_name.contains("://") {
             format!("<{}>", type_name)
         } else {
-            format!("<http://agent-os.org/ontology/{}>", type_name)
+            format!("<https://agent-os.org/ontology/core/{}>", type_name)
         };
         let sparql = format!(
-            "INSERT DATA {{ GRAPH <http://agent-os.org/graph/kg_search> {{ <iri://entity/{}> a {} . \
+            "INSERT DATA {{ GRAPH <https://agent-os.org/graph/kg_search> {{ <iri://entity/{}> a {} . \
              <iri://entity/{}> <http://www.w3.org/2000/01/rdf-schema#label> \"{}\" . }} }}",
             id, type_iri, id, label
         );
@@ -1225,13 +1228,13 @@ fn test_all_bugfixes_stress() {
     blackboard.flush_oxigraph();
 
     // Verify all EvenType nodes via ontology/ namespace
-    let sparql = r#"PREFIX ex: <http://agent-os.org/ontology/>
+    let sparql = r#"PREFIX ex: <https://agent-os.org/ontology/core/>
         SELECT (COUNT(?s) AS ?cnt) WHERE { ?s a ex:EvenType }"#;
     let results = blackboard.query(sparql).unwrap();
     println!("[Stress] EvenType count via SPARQL: {:?}", results);
 
     // Verify all OddType nodes
-    let sparql_odd = r#"PREFIX ex: <http://agent-os.org/ontology/>
+    let sparql_odd = r#"PREFIX ex: <https://agent-os.org/ontology/core/>
         SELECT (COUNT(?s) AS ?cnt) WHERE { ?s a ex:OddType }"#;
     let results_odd = blackboard.query(sparql_odd).unwrap();
     println!("[Stress] OddType count via SPARQL: {:?}", results_odd);
@@ -1268,7 +1271,7 @@ fn test_all_bugfixes_stress() {
     // type/ namespace must be completely empty
     for type_name in &["EvenType", "OddType"] {
         let sparql_old = format!(
-            "SELECT ?s WHERE {{ ?s a <http://agent-os.org/type/{}> }} LIMIT 1",
+            "SELECT ?s WHERE {{ ?s a <https://agent-os.org/type/{}> }} LIMIT 1",
             type_name
         );
         let old_results = blackboard.query(&sparql_old).unwrap();

--- a/tests/integration_mod/test_skill_graph.rs
+++ b/tests/integration_mod/test_skill_graph.rs
@@ -7,9 +7,9 @@ use glidinghorse::skill_graph::*;
 use glidinghorse::tools::{SkillRegistry, ToolExecutor};
 
 const AXURE_TO_VUE2_SKILL_MD: &str =
-    include_str!("../../.trae-test-skills/axure-to-vue2-skill/SKILL.md");
+    include_str!("../fixtures/skills/axure-to-vue2-skill/SKILL.md");
 const AXURE_VUE2_REFACTOR_SKILL_MD: &str =
-    include_str!("../../.trae-test-skills/axure-vue2-refactor/SKILL.md");
+    include_str!("../fixtures/skills/axure-vue2-refactor/SKILL.md");
 
 fn create_test_graph_with_skills() -> Arc<SkillGraphStore> {
     let store = Arc::new(SkillGraphStore::new());
@@ -458,7 +458,7 @@ fn test_skill_creator_register_axure_to_vue2() {
             timeout_seconds: 30,
             max_retries: 1,
             retry_base_ms: 500,
-        use_responses_api: false,
+            use_responses_api: false,
             model_mapping: Default::default(),
         })
         .unwrap(),
@@ -558,7 +558,7 @@ fn test_skill_creator_register_axure_vue2_refactor() {
             timeout_seconds: 30,
             max_retries: 1,
             retry_base_ms: 500,
-        use_responses_api: false,
+            use_responses_api: false,
             model_mapping: Default::default(),
         })
         .unwrap(),
@@ -604,7 +604,7 @@ async fn test_skill_creator_two_skills_coexist() {
             timeout_seconds: 30,
             max_retries: 1,
             retry_base_ms: 500,
-        use_responses_api: false,
+            use_responses_api: false,
             model_mapping: Default::default(),
         })
         .unwrap(),
@@ -744,7 +744,7 @@ fn test_skill_creator_json_ld_validity() {
             timeout_seconds: 30,
             max_retries: 1,
             retry_base_ms: 500,
-        use_responses_api: false,
+            use_responses_api: false,
             model_mapping: Default::default(),
         })
         .unwrap(),
@@ -821,7 +821,7 @@ fn test_skill_creator_disclosure_levels() {
             timeout_seconds: 30,
             max_retries: 1,
             retry_base_ms: 500,
-        use_responses_api: false,
+            use_responses_api: false,
             model_mapping: Default::default(),
         })
         .unwrap(),

--- a/workflow.jsonld
+++ b/workflow.jsonld
@@ -1,9 +1,9 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://pdca-agent.org/ontology/workflow#",
-    "wf": "https://pdca-agent.org/ontology/workflow#",
-    "agent": "https://pdca-agent.org/ontology/agent#"
+    "@vocab": "https://agent-os.org/ontology/workflow#",
+    "wf": "https://agent-os.org/ontology/workflow#",
+    "agent": "https://agent-os.org/ontology/agent#"
   },
   "@graph": [
     {


### PR DESCRIPTION
## Summary

The same semantic concepts were emitted under multiple unrelated IRIs across JSON-LD, RDF materialization, SPARQL projections, memory, skills, and code knowledge.

Examples included:

- `https://pdca-agent.org/...`
- `https://agent-harness.os/...`
- `https://agentos.ontology/...`
- `http://agent-os.org/...`

This breaks the unified JSON-LD/RDF identity model and can make cross-module or cross-graph SPARQL joins silently miss matching triples.

## Changes

- Canonicalize ontology IRIs to `https://agent-os.org/ontology/`
- Preserve intentional domain separation under `core`, `agent`, `task`, `skill`, `memory`, `security`, `monitoring`, `template`, `experience`, `advisory`, `node`, `eng`, `code`, and `biz`
- Update JSON-LD contexts, frames, registry predicates, SPARQL queries, memory writes, skill graph writes, code-AST vocabulary, bridge relations, and fixtures
- Add repository-local skill fixtures so integration tests do not depend on the absent `.trae-test-skills` directory
- Add `scripts/check_namespace.sh` and a CI workflow to prevent legacy namespace drift
- Add `docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md` with migration and historical-data guidance

## Validation

- `bash scripts/check_namespace.sh` passed
- JSON-LD regression tests: 30 passed
- Non-network integration tests: 95 passed, 19 ignored
- Two external DeepSeek tests were skipped because `DEEPSEEK_API_KEY` is not configured locally
- Changed Rust files pass targeted rustfmt checks

## Documentation

See [`docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md`](https://github.com/skaiy/gliding_test/blob/fix/ontology-namespace-consistency/docs/16-ONTOLOGY_NAMESPACE_MIGRATION.md).