### PR TITLE
Document optional Parallel Search MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ export EXA_API_KEY="your-exa-api-key"
 # With MCP server attached
 ./glidingcode --mcp-server chrome=http://localhost:3000/sse
 
+# Optional: use Parallel Search MCP (no account or API key required)
+# Chosen queries and requested URLs are sent to Parallel.
+./glidingcode --mcp-server parallel-search=https://search.parallel.ai/mcp
+
 # Resume from checkpoint
 ./glidingcode --resume task:abc123
 ```


### PR DESCRIPTION
## Summary

- add an optional Parallel Search MCP command next to the existing HTTP MCP quickstart example
- note that it requires no account or API key
- disclose that chosen queries and requested URLs are sent to Parallel
- preserve the existing Chrome MCP example and web-search configuration

## Validation

- `git diff --check`
- verified `README.md` is the only changed path
- verified the command and disclosure text each appear exactly once

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.